### PR TITLE
Fix the problem that character may stop between tiles.

### DIFF
--- a/Assets/Scenes/DemoPuzzleScene.unity
+++ b/Assets/Scenes/DemoPuzzleScene.unity
@@ -1853,7 +1853,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6dd7f0b5c9fd4b1a9a029630356272d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  singlePlayer: 0
+  singlePlayer: 1
 --- !u!4 &1256660028
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Character/CharacterInputManager.cs
+++ b/Assets/Scripts/Character/CharacterInputManager.cs
@@ -28,7 +28,7 @@ public class CharacterInputManager : MonoBehaviour
             if (gameObject.name.Contains("2P"))
             {
                 input.SwitchCurrentActionMap("1PGridMovement");
-                movement.enabled = false;
+                movement.acceptingInput = false;
             }
         }
     }
@@ -36,6 +36,6 @@ public class CharacterInputManager : MonoBehaviour
     public void OnSwitch()
     {
         if (!isSinglePlayer) return;
-        movement.enabled = !movement.enabled;
+        movement.acceptingInput = !movement.acceptingInput;
     }
 }

--- a/Assets/Scripts/Character/GridMovement.cs
+++ b/Assets/Scripts/Character/GridMovement.cs
@@ -115,26 +115,46 @@ public class GridMovement : MonoBehaviour
         }
     }
 
+    private bool _acceptingInput = true;
+    public bool acceptingInput
+    {
+        get => _acceptingInput;
+        set
+        {
+            if (!value)
+            {
+                //force stop
+                currentAction = Action.NONE;
+                movement = Vector2.zero;
+            }
+            _acceptingInput = value;
+        }
+    }
+
     public void OnUp(InputValue value)
     {
+        if (!acceptingInput) return;
         Debug.Log("Up");
         changeMovement(Action.UP, value.isPressed, 0.5f, 0.5f);
     }
 
     public void OnRight(InputValue value)
     {
+        if (!acceptingInput) return;
         Debug.Log("Right");
         changeMovement(Action.RIGHT, value.isPressed, 0.5f, -0.5f);
     }
 
     public void OnLeft(InputValue value)
     {
+        if (!acceptingInput) return;
         Debug.Log("Left");
         changeMovement(Action.LEFT, value.isPressed, -0.5f, 0.5f);
     }
 
     public void OnDown(InputValue value)
     {
+        if (!acceptingInput) return;
         Debug.Log("Down");
         changeMovement(Action.DOWN, value.isPressed, -0.5f, -0.5f);
     }


### PR DESCRIPTION
In the old GridMovement, the character may stop between 2 tiles when we switch control too quickly (in single-player mode).
This PR fixes that.