### PR TITLE
Character collider adjustment

### DIFF
--- a/Assets/Scenes/secminhr_test_scene.unity
+++ b/Assets/Scenes/secminhr_test_scene.unity
@@ -254,12 +254,12 @@ PrefabInstance:
     - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.54
+      value: 0.498
       objectReference: {fileID: 0}
     - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.98
+      value: -1.02
       objectReference: {fileID: 0}
     - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
@@ -331,6 +331,11 @@ PrefabInstance:
       propertyPath: tilemap
       value: 
       objectReference: {fileID: 1568558543}
+    - target: {fileID: 2470534266370304799, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: movingSpeed
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 7145938262029683916, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: otherInteractor
@@ -3101,6 +3106,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2084451319}
     m_Modifications:
+    - target: {fileID: 6081139256600177526, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
         type: 3}
       propertyPath: m_Color.b
@@ -3239,12 +3249,12 @@ PrefabInstance:
     - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.967
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.172
+      value: -0.171
       objectReference: {fileID: 0}
     - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
@@ -3299,7 +3309,7 @@ PrefabInstance:
     - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
       propertyPath: m_Size.x
-      value: 0.19321382
+      value: 0.27641523
       objectReference: {fileID: 0}
     - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
@@ -3314,7 +3324,7 @@ PrefabInstance:
     - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
       propertyPath: m_Offset.x
-      value: -0.011879265
+      value: -0.05347997
       objectReference: {fileID: 0}
     - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
@@ -3340,6 +3350,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218979018150120, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8807749665105663781, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
@@ -3873,10 +3888,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb406fdbecaaa4831b72ebcdc806a9e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  UDCollider: {fileID: 1097655431}
-  LRCollider: {fileID: 1097655430}
---- !u!68 &1097655430
-EdgeCollider2D:
+  characterCollider: {fileID: 1097655442}
+--- !u!893571522 &1097655441
+CustomCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -3885,40 +3899,52 @@ EdgeCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_EdgeRadius: 0
-  m_Points:
-  - {x: -0.2362243, y: 0.048856795}
-  - {x: 0.22232068, y: -0.111071765}
-  m_AdjacentStartPoint: {x: 0, y: 0}
-  m_AdjacentEndPoint: {x: 0, y: 0}
-  m_UseAdjacentStartPoint: 0
-  m_UseAdjacentEndPoint: 0
---- !u!68 &1097655431
-EdgeCollider2D:
+  m_CustomShapes:
+    m_Shapes:
+    - m_ShapeType: 2
+      m_Radius: 0
+      m_VertexStartIndex: 0
+      m_VertexCount: 4
+      m_UseAdjacentStart: 0
+      m_UseAdjacentEnd: 0
+      m_AdjacentStart: {x: 0, y: 0}
+      m_AdjacentEnd: {x: 0, y: 0}
+    - m_ShapeType: 2
+      m_Radius: 0
+      m_VertexStartIndex: 4
+      m_VertexCount: 4
+      m_UseAdjacentStart: 0
+      m_UseAdjacentEnd: 0
+      m_AdjacentStart: {x: 0, y: 0}
+      m_AdjacentEnd: {x: 0, y: 0}
+    m_Vertices:
+    - {x: 0.15, y: -0.05103093}
+    - {x: -0.15, y: 0.05103093}
+    - {x: -0.14706062, y: 0.052030932}
+    - {x: 0.15293941, y: -0.05003093}
+    - {x: -0.15, y: -0.05103093}
+    - {x: 0.15, y: 0.05103093}
+    - {x: 0.14706062, y: 0.052030932}
+    - {x: -0.15293941, y: -0.05003093}
+--- !u!114 &1097655442
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1097655420}
   m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_EdgeRadius: 0
-  m_Points:
-  - {x: -0.2858357, y: -0.11552554}
-  - {x: 0.18592966, y: 0.044867218}
-  m_AdjacentStartPoint: {x: 0, y: 0}
-  m_AdjacentEndPoint: {x: 0, y: 0}
-  m_UseAdjacentStartPoint: 0
-  m_UseAdjacentEndPoint: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8584a455d02cc47b6acb7d2227a82e5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  customCollider: {fileID: 1097655441}
+  grid: {fileID: 2084451318}
+  scale: 0.3
 --- !u!1 &1161721683
 GameObject:
   m_ObjectHideFlags: 0
@@ -3938,7 +3964,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1161721684
 Transform:
   m_ObjectHideFlags: 0
@@ -8226,32 +8252,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb406fdbecaaa4831b72ebcdc806a9e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  UDCollider: {fileID: 2063741031}
-  LRCollider: {fileID: 2063741032}
---- !u!68 &2063741031
-EdgeCollider2D:
+  characterCollider: {fileID: 2063741042}
+--- !u!114 &2063741042
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2063741017}
   m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_EdgeRadius: 0
-  m_Points:
-  - {x: -0.2616284, y: -0.07397726}
-  - {x: 0.18765116, y: 0.09041679}
-  m_AdjacentStartPoint: {x: 0, y: 0}
-  m_AdjacentEndPoint: {x: 0, y: 0}
-  m_UseAdjacentStartPoint: 0
-  m_UseAdjacentEndPoint: 0
---- !u!68 &2063741032
-EdgeCollider2D:
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8584a455d02cc47b6acb7d2227a82e5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  customCollider: {fileID: 2063741043}
+  grid: {fileID: 2084451318}
+  scale: 0.3
+--- !u!893571522 &2063741043
+CustomCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -8264,14 +8282,33 @@ EdgeCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_EdgeRadius: 0
-  m_Points:
-  - {x: -0.24107909, y: 0.09452665}
-  - {x: 0.22053003, y: -0.069867566}
-  m_AdjacentStartPoint: {x: 0, y: 0}
-  m_AdjacentEndPoint: {x: 0, y: 0}
-  m_UseAdjacentStartPoint: 0
-  m_UseAdjacentEndPoint: 0
+  m_CustomShapes:
+    m_Shapes:
+    - m_ShapeType: 2
+      m_Radius: 0
+      m_VertexStartIndex: 0
+      m_VertexCount: 4
+      m_UseAdjacentStart: 0
+      m_UseAdjacentEnd: 0
+      m_AdjacentStart: {x: 0, y: 0}
+      m_AdjacentEnd: {x: 0, y: 0}
+    - m_ShapeType: 2
+      m_Radius: 0
+      m_VertexStartIndex: 4
+      m_VertexCount: 4
+      m_UseAdjacentStart: 0
+      m_UseAdjacentEnd: 0
+      m_AdjacentStart: {x: 0, y: 0}
+      m_AdjacentEnd: {x: 0, y: 0}
+    m_Vertices:
+    - {x: 0.15, y: -0.05103093}
+    - {x: -0.15, y: 0.05103093}
+    - {x: -0.14706062, y: 0.052030932}
+    - {x: 0.15293941, y: -0.05003093}
+    - {x: -0.15, y: -0.05103093}
+    - {x: 0.15, y: 0.05103093}
+    - {x: 0.14706062, y: 0.052030932}
+    - {x: -0.15293941, y: -0.05003093}
 --- !u!1001 &2066823331
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/secminhr_test_scene.unity
+++ b/Assets/Scenes/secminhr_test_scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731689, g: 0.13414702, b: 0.1210784, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -125,3123 +125,380 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &109615036
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 109615037}
-  - component: {fileID: 109615042}
-  - component: {fileID: 109615041}
-  - component: {fileID: 109615040}
-  - component: {fileID: 109615039}
-  - component: {fileID: 109615038}
-  m_Layer: 6
-  m_Name: Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &109615037
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!66 &109615038
-CompositeCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_GeometryType: 0
-  m_GenerationType: 0
-  m_EdgeRadius: 0
-  m_ColliderPaths:
-  - m_Collider: {fileID: 109615040}
-    m_ColliderPaths:
-    - - X: -238095
-        Y: 40919712
-      - X: -9666667
-        Y: 40919712
-      - X: -9666667
-        Y: 40729236
-      - X: -238095
-        Y: 40729236
-    - - X: 9761904
-        Y: 40919712
-      - X: 333332
-        Y: 40919712
-      - X: 333332
-        Y: 40729236
-      - X: 9761904
-        Y: 40729236
-    - - X: -5238095
-        Y: 39218684
-      - X: -14666667
-        Y: 39218684
-      - X: -14666667
-        Y: 39028204
-      - X: -5238095
-        Y: 39028204
-    - - X: -10238094
-        Y: 37517652
-      - X: -19666666
-        Y: 37517652
-      - X: -19666666
-        Y: 37327176
-      - X: -10238094
-        Y: 37327176
-    - - X: -15238094
-        Y: 35816620
-      - X: -24666666
-        Y: 35816620
-      - X: -24666666
-        Y: 35626144
-      - X: -15238094
-        Y: 35626144
-    - - X: 4761905
-        Y: 35816620
-      - X: -4666667
-        Y: 35816620
-      - X: -4666667
-        Y: 35626144
-      - X: 4761905
-        Y: 35626144
-    - - X: -20238094
-        Y: 34115592
-      - X: -29666666
-        Y: 34115592
-      - X: -29666666
-        Y: 33925112
-      - X: -20238094
-        Y: 33925112
-    - - X: 29761906
-        Y: 34115592
-      - X: 20333334
-        Y: 34115592
-      - X: 20333334
-        Y: 33925112
-      - X: 29761906
-        Y: 33925112
-    - - X: -238095
-        Y: 34115592
-      - X: -9666667
-        Y: 34115592
-      - X: -9666667
-        Y: 33925112
-      - X: -238095
-        Y: 33925112
-    - - X: -25238094
-        Y: 32414560
-      - X: -34666668
-        Y: 32414560
-      - X: -34666668
-        Y: 32224082
-      - X: -25238094
-        Y: 32224082
-    - - X: 34761904
-        Y: 32414560
-      - X: 25333334
-        Y: 32414560
-      - X: 25333334
-        Y: 32224082
-      - X: 34761904
-        Y: 32224082
-    - - X: -30238094
-        Y: 30713530
-      - X: -39666668
-        Y: 30713530
-      - X: -39666668
-        Y: 30523052
-      - X: -30238094
-        Y: 30523052
-    - - X: 39761904
-        Y: 30713530
-      - X: 30333334
-        Y: 30713530
-      - X: 30333334
-        Y: 30523052
-      - X: 39761904
-        Y: 30523052
-    - - X: 19761906
-        Y: 30713530
-      - X: 10333333
-        Y: 30713530
-      - X: 10333333
-        Y: 30523052
-      - X: 19761906
-        Y: 30523052
-    - - X: -10238094
-        Y: 30713530
-      - X: -19666666
-        Y: 30713530
-      - X: -19666666
-        Y: 30523052
-      - X: -10238094
-        Y: 30523052
-    - - X: 9761904
-        Y: 30713530
-      - X: 333332
-        Y: 30713530
-      - X: 333332
-        Y: 30523052
-      - X: 9761904
-        Y: 30523052
-    - - X: -35238096
-        Y: 29012498
-      - X: -44666668
-        Y: 29012498
-      - X: -44666668
-        Y: 28822022
-      - X: -35238096
-        Y: 28822022
-    - - X: -15238094
-        Y: 29012498
-      - X: -24666666
-        Y: 29012498
-      - X: -24666666
-        Y: 28822022
-      - X: -15238094
-        Y: 28822022
-    - - X: 14761906
-        Y: 29012498
-      - X: 5333333
-        Y: 29012498
-      - X: 5333333
-        Y: 28822022
-      - X: 14761906
-        Y: 28822022
-    - - X: -20238094
-        Y: 27311468
-      - X: -29666666
-        Y: 27311468
-      - X: -29666666
-        Y: 27120990
-      - X: -20238094
-        Y: 27120990
-    - - X: -238095
-        Y: 27311468
-      - X: -9666667
-        Y: 27311468
-      - X: -9666667
-        Y: 27120990
-      - X: -238095
-        Y: 27120990
-    - - X: 39761904
-        Y: 27311468
-      - X: 30333334
-        Y: 27311468
-      - X: 30333334
-        Y: 27120990
-      - X: 39761904
-        Y: 27120990
-    - - X: 29761906
-        Y: 27311468
-      - X: 20333334
-        Y: 27311468
-      - X: 20333334
-        Y: 27120990
-      - X: 29761906
-        Y: 27120990
-    - - X: -35238096
-        Y: 25610438
-      - X: -44666668
-        Y: 25610438
-      - X: -44666668
-        Y: 25419960
-      - X: -35238096
-        Y: 25419960
-    - - X: 4761905
-        Y: 25610438
-      - X: -4666667
-        Y: 25610438
-      - X: -4666667
-        Y: 25419960
-      - X: 4761905
-        Y: 25419960
-    - - X: -25238094
-        Y: 25610438
-      - X: -34666668
-        Y: 25610438
-      - X: -34666668
-        Y: 25419960
-      - X: -25238094
-        Y: 25419960
-    - - X: -238095
-        Y: 23909406
-      - X: -9666667
-        Y: 23909406
-      - X: -9666667
-        Y: 23718930
-      - X: -238095
-        Y: 23718930
-    - - X: 19761906
-        Y: 23909406
-      - X: 10333333
-        Y: 23909406
-      - X: 10333333
-        Y: 23718930
-      - X: 19761906
-        Y: 23718930
-    - - X: -5238095
-        Y: 22208376
-      - X: -14666667
-        Y: 22208376
-      - X: -14666667
-        Y: 22017898
-      - X: -5238095
-        Y: 22017898
-    - - X: 14761906
-        Y: 22208376
-      - X: 5333333
-        Y: 22208376
-      - X: 5333333
-        Y: 22017898
-      - X: 14761906
-        Y: 22017898
-    - - X: -10238094
-        Y: 20507342
-      - X: -19666666
-        Y: 20507342
-      - X: -19666666
-        Y: 20316868
-      - X: -10238094
-        Y: 20316868
-    - - X: 29761906
-        Y: 20507342
-      - X: 20333334
-        Y: 20507342
-      - X: 20333334
-        Y: 20316868
-      - X: 29761906
-        Y: 20316868
-    - - X: 9761904
-        Y: 20507342
-      - X: 333332
-        Y: 20507342
-      - X: 333332
-        Y: 20316868
-      - X: 9761904
-        Y: 20316868
-    - - X: 14761906
-        Y: 18806312
-      - X: 5333333
-        Y: 18806312
-      - X: 5333333
-        Y: 18615836
-      - X: 14761906
-        Y: 18615836
-    - - X: 24761906
-        Y: 18806312
-      - X: 15333333
-        Y: 18806312
-      - X: 15333333
-        Y: 18615836
-      - X: 24761906
-        Y: 18615836
-    - - X: 4761905
-        Y: 18806312
-      - X: -4666667
-        Y: 18806312
-      - X: -4666667
-        Y: 18615836
-      - X: 4761905
-        Y: 18615836
-    - - X: -238095
-        Y: 17105282
-      - X: -9666667
-        Y: 17105282
-      - X: -9666667
-        Y: 16914806
-      - X: -238095
-        Y: 16914806
-    - - X: 19761906
-        Y: 17105282
-      - X: 10333333
-        Y: 17105282
-      - X: 10333333
-        Y: 16914806
-      - X: 19761906
-        Y: 16914806
-    - - X: -10238094
-        Y: 17105282
-      - X: -19666666
-        Y: 17105282
-      - X: -19666666
-        Y: 16914806
-      - X: -10238094
-        Y: 16914806
-    - - X: 9761904
-        Y: 13703220
-      - X: 333332
-        Y: 13703220
-      - X: 333332
-        Y: 13512744
-      - X: 9761904
-        Y: 13512744
-    - - X: -238095
-        Y: 13703220
-      - X: -9666667
-        Y: 13703220
-      - X: -9666667
-        Y: 13512744
-      - X: -238095
-        Y: 13512744
-    - - X: 14761906
-        Y: 12002189
-      - X: 5333333
-        Y: 12002189
-      - X: 5333333
-        Y: 11811713
-      - X: 14761906
-        Y: 11811713
-    - - X: -5238095
-        Y: 12002189
-      - X: -14666667
-        Y: 12002189
-      - X: -14666667
-        Y: 11811713
-      - X: -5238095
-        Y: 11811713
-    - - X: -10238094
-        Y: 10301158
-      - X: -19666666
-        Y: 10301158
-      - X: -19666666
-        Y: 10110682
-      - X: -10238094
-        Y: 10110682
-    - - X: 19761906
-        Y: 10301158
-      - X: 10333333
-        Y: 10301158
-      - X: 10333333
-        Y: 10110682
-      - X: 19761906
-        Y: 10110682
-    - - X: -15238094
-        Y: 8600128
-      - X: -24666666
-        Y: 8600128
-      - X: -24666666
-        Y: 8409652
-      - X: -15238094
-        Y: 8409652
-    - - X: 24761906
-        Y: 8600128
-      - X: 15333333
-        Y: 8600128
-      - X: 15333333
-        Y: 8409652
-      - X: 24761906
-        Y: 8409652
-    - - X: -20238094
-        Y: 6899097
-      - X: -29666666
-        Y: 6899097
-      - X: -29666666
-        Y: 6708621
-      - X: -20238094
-        Y: 6708621
-    - - X: 29761906
-        Y: 6899097
-      - X: 20333334
-        Y: 6899097
-      - X: 20333334
-        Y: 6708621
-      - X: 29761906
-        Y: 6708621
-    - - X: -25238094
-        Y: 5198065
-      - X: -34666668
-        Y: 5198065
-      - X: -34666668
-        Y: 5007589
-      - X: -25238094
-        Y: 5007589
-    - - X: 34761904
-        Y: 5198065
-      - X: 25333334
-        Y: 5198065
-      - X: 25333334
-        Y: 5007589
-      - X: 34761904
-        Y: 5007589
-    - - X: -30238094
-        Y: 3497035
-      - X: -39666668
-        Y: 3497035
-      - X: -39666668
-        Y: 3306558
-      - X: -30238094
-        Y: 3306558
-    - - X: 39761904
-        Y: 3497035
-      - X: 30333334
-        Y: 3497035
-      - X: 30333334
-        Y: 3306558
-      - X: 39761904
-        Y: 3306558
-    - - X: -35238096
-        Y: 1796004
-      - X: -44666668
-        Y: 1796004
-      - X: -44666668
-        Y: 1605528
-      - X: -35238096
-        Y: 1605528
-    - - X: 44761904
-        Y: 1796004
-      - X: 35333332
-        Y: 1796004
-      - X: 35333332
-        Y: 1605528
-      - X: 44761904
-        Y: 1605528
-    - - X: 44761904
-        Y: -1606057
-      - X: 35333332
-        Y: -1606057
-      - X: 35333332
-        Y: -1796533
-      - X: 44761904
-        Y: -1796533
-    - - X: -30238094
-        Y: -3307088
-      - X: -39666668
-        Y: -3307088
-      - X: -39666668
-        Y: -3497564
-      - X: -30238094
-        Y: -3497564
-    - - X: 39761904
-        Y: -3307088
-      - X: 30333334
-        Y: -3307088
-      - X: 30333334
-        Y: -3497564
-      - X: 39761904
-        Y: -3497564
-    - - X: -25238094
-        Y: -5008119
-      - X: -34666668
-        Y: -5008119
-      - X: -34666668
-        Y: -5198595
-      - X: -25238094
-        Y: -5198595
-    - - X: 34761904
-        Y: -5008119
-      - X: 25333334
-        Y: -5008119
-      - X: 25333334
-        Y: -5198595
-      - X: 34761904
-        Y: -5198595
-    - - X: 29761906
-        Y: -6709150
-      - X: 20333334
-        Y: -6709150
-      - X: 20333334
-        Y: -6899626
-      - X: 29761906
-        Y: -6899626
-    - - X: -20238094
-        Y: -6709150
-      - X: -29666666
-        Y: -6709150
-      - X: -29666666
-        Y: -6899626
-      - X: -20238094
-        Y: -6899626
-    - - X: -15238094
-        Y: -8410182
-      - X: -24666666
-        Y: -8410182
-      - X: -24666666
-        Y: -8600658
-      - X: -15238094
-        Y: -8600658
-    - - X: 24761906
-        Y: -8410182
-      - X: 15333333
-        Y: -8410182
-      - X: 15333333
-        Y: -8600658
-      - X: 24761906
-        Y: -8600658
-    - - X: -10238094
-        Y: -10111213
-      - X: -19666666
-        Y: -10111213
-      - X: -19666666
-        Y: -10301689
-      - X: -10238094
-        Y: -10301689
-    - - X: 19761906
-        Y: -10111213
-      - X: 10333333
-        Y: -10111213
-      - X: 10333333
-        Y: -10301689
-      - X: 19761906
-        Y: -10301689
-    - - X: -5238095
-        Y: -11812243
-      - X: -14666667
-        Y: -11812243
-      - X: -14666667
-        Y: -12002720
-      - X: -5238095
-        Y: -12002720
-    - - X: 14761906
-        Y: -11812243
-      - X: 5333333
-        Y: -11812243
-      - X: 5333333
-        Y: -12002720
-      - X: 14761906
-        Y: -12002720
-    - - X: -238095
-        Y: -13513274
-      - X: -9666667
-        Y: -13513274
-      - X: -9666667
-        Y: -13703750
-      - X: -238095
-        Y: -13703750
-    - - X: 9761904
-        Y: -13513274
-      - X: 333332
-        Y: -13513274
-      - X: 333332
-        Y: -13703750
-      - X: 9761904
-        Y: -13703750
-  m_CompositePaths:
-    m_Paths:
-    - - {x: 0.9761611, y: 4.0729237}
-      - {x: 0.9761611, y: 4.0919714}
-      - {x: 0.0333332, y: 4.091942}
-      - {x: 0.0333625, y: 4.0729237}
-    - - {x: -0.0238388, y: 4.0729237}
-      - {x: -0.0238388, y: 4.0919714}
-      - {x: -0.9666667, y: 4.091942}
-      - {x: -0.96663743, y: 4.0729237}
-    - - {x: -0.5238388, y: 3.9028203}
-      - {x: -0.5238388, y: 3.9218686}
-      - {x: -1.4666667, y: 3.9218392}
-      - {x: -1.4666374, y: 3.9028203}
-    - - {x: -1.0238388, y: 3.7327178}
-      - {x: -1.0238388, y: 3.7517653}
-      - {x: -1.9666666, y: 3.751736}
-      - {x: -1.9666373, y: 3.7327178}
-    - - {x: 0.4761612, y: 3.5626144}
-      - {x: 0.4761612, y: 3.581662}
-      - {x: -0.4666667, y: 3.5816329}
-      - {x: -0.4666374, y: 3.5626144}
-    - - {x: -1.5238388, y: 3.5626144}
-      - {x: -1.5238388, y: 3.581662}
-      - {x: -2.4666667, y: 3.5816329}
-      - {x: -2.4666371, y: 3.5626144}
-    - - {x: 2.9761612, y: 3.3925111}
-      - {x: 2.9761612, y: 3.4115593}
-      - {x: 2.0333335, y: 3.41153}
-      - {x: 2.0333629, y: 3.3925111}
-    - - {x: -0.0238388, y: 3.3925111}
-      - {x: -0.0238388, y: 3.4115593}
-      - {x: -0.9666667, y: 3.41153}
-      - {x: -0.96663743, y: 3.3925111}
-    - - {x: -2.0238388, y: 3.3925111}
-      - {x: -2.0238388, y: 3.4115593}
-      - {x: -2.9666667, y: 3.41153}
-      - {x: -2.9666371, y: 3.3925111}
-    - - {x: 3.4761612, y: 3.2224083}
-      - {x: 3.4761612, y: 3.241456}
-      - {x: 2.5333335, y: 3.241427}
-      - {x: 2.5333629, y: 3.2224083}
-    - - {x: -2.5238388, y: 3.2224083}
-      - {x: -2.5238388, y: 3.241456}
-      - {x: -3.466667, y: 3.241427}
-      - {x: -3.4666376, y: 3.2224083}
-    - - {x: 3.9761612, y: 3.0523052}
-      - {x: 3.9761612, y: 3.071353}
-      - {x: 3.0333335, y: 3.0713236}
-      - {x: 3.0333629, y: 3.0523052}
-    - - {x: 1.9761612, y: 3.0523052}
-      - {x: 1.9761612, y: 3.071353}
-      - {x: 1.0333333, y: 3.0713236}
-      - {x: 1.0333626, y: 3.0523052}
-    - - {x: 0.9761611, y: 3.0523052}
-      - {x: 0.9761611, y: 3.071353}
-      - {x: 0.0333332, y: 3.0713236}
-      - {x: 0.0333625, y: 3.0523052}
-    - - {x: -1.0238388, y: 3.0523052}
-      - {x: -1.0238388, y: 3.071353}
-      - {x: -1.9666666, y: 3.0713236}
-      - {x: -1.9666373, y: 3.0523052}
-    - - {x: -3.0238388, y: 3.0523052}
-      - {x: -3.0238388, y: 3.071353}
-      - {x: -3.966667, y: 3.0713236}
-      - {x: -3.9666376, y: 3.0523052}
-    - - {x: 1.4761614, y: 2.8822021}
-      - {x: 1.4761614, y: 2.90125}
-      - {x: 0.5333333, y: 2.9012203}
-      - {x: 0.5333626, y: 2.8822021}
-    - - {x: -1.5238388, y: 2.8822021}
-      - {x: -1.5238388, y: 2.90125}
-      - {x: -2.4666667, y: 2.9012203}
-      - {x: -2.4666371, y: 2.8822021}
-    - - {x: -3.5238388, y: 2.8822021}
-      - {x: -3.5238388, y: 2.90125}
-      - {x: -4.4666667, y: 2.9012203}
-      - {x: -4.4666376, y: 2.8822021}
-    - - {x: 3.9761612, y: 2.712099}
-      - {x: 3.9761612, y: 2.7311468}
-      - {x: 3.0333335, y: 2.7311177}
-      - {x: 3.0333629, y: 2.712099}
-    - - {x: 2.9761612, y: 2.712099}
-      - {x: 2.9761612, y: 2.7311468}
-      - {x: 2.0333335, y: 2.7311177}
-      - {x: 2.0333629, y: 2.712099}
-    - - {x: -0.0238388, y: 2.712099}
-      - {x: -0.0238388, y: 2.7311468}
-      - {x: -0.9666667, y: 2.7311177}
-      - {x: -0.96663743, y: 2.712099}
-    - - {x: -2.0238388, y: 2.712099}
-      - {x: -2.0238388, y: 2.7311468}
-      - {x: -2.9666667, y: 2.7311177}
-      - {x: -2.9666371, y: 2.712099}
-    - - {x: 0.4761612, y: 2.541996}
-      - {x: 0.4761612, y: 2.5610437}
-      - {x: -0.4666667, y: 2.5610144}
-      - {x: -0.4666374, y: 2.541996}
-    - - {x: -2.5238388, y: 2.541996}
-      - {x: -2.5238388, y: 2.5610437}
-      - {x: -3.466667, y: 2.5610144}
-      - {x: -3.4666376, y: 2.541996}
-    - - {x: -3.5238388, y: 2.541996}
-      - {x: -3.5238388, y: 2.5610437}
-      - {x: -4.4666667, y: 2.5610144}
-      - {x: -4.4666376, y: 2.541996}
-    - - {x: 1.9761612, y: 2.371893}
-      - {x: 1.9761612, y: 2.3909407}
-      - {x: 1.0333333, y: 2.3909113}
-      - {x: 1.0333626, y: 2.371893}
-    - - {x: -0.0238388, y: 2.371893}
-      - {x: -0.0238388, y: 2.3909407}
-      - {x: -0.9666667, y: 2.3909113}
-      - {x: -0.96663743, y: 2.371893}
-    - - {x: 1.4761614, y: 2.2017899}
-      - {x: 1.4761614, y: 2.2208376}
-      - {x: 0.5333333, y: 2.2208085}
-      - {x: 0.5333626, y: 2.2017899}
-    - - {x: -0.5238388, y: 2.2017899}
-      - {x: -0.5238388, y: 2.2208376}
-      - {x: -1.4666667, y: 2.2208085}
-      - {x: -1.4666374, y: 2.2017899}
-    - - {x: 2.9761612, y: 2.0316868}
-      - {x: 2.9761612, y: 2.0507343}
-      - {x: 2.0333335, y: 2.0507047}
-      - {x: 2.0333629, y: 2.0316868}
-    - - {x: 0.9761611, y: 2.0316868}
-      - {x: 0.9761611, y: 2.0507343}
-      - {x: 0.0333332, y: 2.0507047}
-      - {x: 0.0333625, y: 2.0316868}
-    - - {x: -1.0238388, y: 2.0316868}
-      - {x: -1.0238388, y: 2.0507343}
-      - {x: -1.9666666, y: 2.0507047}
-      - {x: -1.9666373, y: 2.0316868}
-    - - {x: 2.4761612, y: 1.8615836}
-      - {x: 2.4761612, y: 1.8806312}
-      - {x: 1.5333333, y: 1.880602}
-      - {x: 1.5333626, y: 1.8615836}
-    - - {x: 1.4761614, y: 1.8615836}
-      - {x: 1.4761614, y: 1.8806312}
-      - {x: 0.5333333, y: 1.880602}
-      - {x: 0.5333626, y: 1.8615836}
-    - - {x: 0.4761612, y: 1.8615836}
-      - {x: 0.4761612, y: 1.8806312}
-      - {x: -0.4666667, y: 1.880602}
-      - {x: -0.4666374, y: 1.8615836}
-    - - {x: 1.9761612, y: 1.6914806}
-      - {x: 1.9761612, y: 1.7105283}
-      - {x: 1.0333333, y: 1.7104988}
-      - {x: 1.0333626, y: 1.6914806}
-    - - {x: -0.0238388, y: 1.6914806}
-      - {x: -0.0238388, y: 1.7105283}
-      - {x: -0.9666667, y: 1.7104988}
-      - {x: -0.96663743, y: 1.6914806}
-    - - {x: -1.0238388, y: 1.6914806}
-      - {x: -1.0238388, y: 1.7105283}
-      - {x: -1.9666666, y: 1.7104988}
-      - {x: -1.9666373, y: 1.6914806}
-    - - {x: 0.9761611, y: 1.3512744}
-      - {x: 0.9761611, y: 1.370322}
-      - {x: 0.0333332, y: 1.3702927}
-      - {x: 0.0333625, y: 1.3512744}
-    - - {x: -0.0238388, y: 1.3512744}
-      - {x: -0.0238388, y: 1.370322}
-      - {x: -0.9666667, y: 1.3702927}
-      - {x: -0.96663743, y: 1.3512744}
-    - - {x: 1.4761614, y: 1.1811713}
-      - {x: 1.4761614, y: 1.2002189}
-      - {x: 0.5333333, y: 1.2001896}
-      - {x: 0.5333626, y: 1.1811713}
-    - - {x: -0.5238388, y: 1.1811713}
-      - {x: -0.5238388, y: 1.2002189}
-      - {x: -1.4666667, y: 1.2001896}
-      - {x: -1.4666374, y: 1.1811713}
-    - - {x: 1.9761612, y: 1.0110682}
-      - {x: 1.9761612, y: 1.0301158}
-      - {x: 1.0333333, y: 1.0300865}
-      - {x: 1.0333626, y: 1.0110682}
-    - - {x: -1.0238388, y: 1.0110682}
-      - {x: -1.0238388, y: 1.0301158}
-      - {x: -1.9666666, y: 1.0300865}
-      - {x: -1.9666373, y: 1.0110682}
-    - - {x: 2.4761612, y: 0.8409652}
-      - {x: 2.4761612, y: 0.8600128}
-      - {x: 1.5333333, y: 0.8599835}
-      - {x: 1.5333626, y: 0.8409652}
-    - - {x: -1.5238388, y: 0.8409652}
-      - {x: -1.5238388, y: 0.8600128}
-      - {x: -2.4666667, y: 0.8599835}
-      - {x: -2.4666371, y: 0.8409652}
-    - - {x: 2.9761612, y: 0.6708621}
-      - {x: 2.9761612, y: 0.6899097}
-      - {x: 2.0333335, y: 0.68988043}
-      - {x: 2.0333629, y: 0.6708621}
-    - - {x: -2.0238388, y: 0.6708621}
-      - {x: -2.0238388, y: 0.6899097}
-      - {x: -2.9666667, y: 0.68988043}
-      - {x: -2.9666371, y: 0.6708621}
-    - - {x: 3.4761612, y: 0.5007589}
-      - {x: 3.4761612, y: 0.5198065}
-      - {x: 2.5333335, y: 0.5197772}
-      - {x: 2.5333629, y: 0.5007589}
-    - - {x: -2.5238388, y: 0.5007589}
-      - {x: -2.5238388, y: 0.5198065}
-      - {x: -3.466667, y: 0.5197772}
-      - {x: -3.4666376, y: 0.5007589}
-    - - {x: 3.9761612, y: 0.3306558}
-      - {x: 3.9761612, y: 0.3497035}
-      - {x: 3.0333335, y: 0.3496742}
-      - {x: 3.0333629, y: 0.3306558}
-    - - {x: -3.0238388, y: 0.3306558}
-      - {x: -3.0238388, y: 0.3497035}
-      - {x: -3.966667, y: 0.3496742}
-      - {x: -3.9666376, y: 0.3306558}
-    - - {x: 4.4761615, y: 0.1605528}
-      - {x: 4.4761615, y: 0.1796004}
-      - {x: 3.5333333, y: 0.1795711}
-      - {x: 3.5333624, y: 0.1605528}
-    - - {x: -3.5238388, y: 0.1605528}
-      - {x: -3.5238388, y: 0.1796004}
-      - {x: -4.4666667, y: 0.1795711}
-      - {x: -4.4666376, y: 0.1605528}
-    - - {x: 4.4761615, y: -0.1796533}
-      - {x: 4.4761615, y: -0.1606057}
-      - {x: 3.5333333, y: -0.160635}
-      - {x: 3.5333624, y: -0.1796533}
-    - - {x: 3.9761612, y: -0.3497564}
-      - {x: 3.9761612, y: -0.3307088}
-      - {x: 3.0333335, y: -0.3307381}
-      - {x: 3.0333629, y: -0.3497564}
-    - - {x: -3.0238388, y: -0.3497564}
-      - {x: -3.0238388, y: -0.3307088}
-      - {x: -3.966667, y: -0.3307381}
-      - {x: -3.9666376, y: -0.3497564}
-    - - {x: 3.4761612, y: -0.5198595}
-      - {x: 3.4761612, y: -0.50081193}
-      - {x: 2.5333335, y: -0.5008412}
-      - {x: 2.5333629, y: -0.5198595}
-    - - {x: -2.5238388, y: -0.5198595}
-      - {x: -2.5238388, y: -0.50081193}
-      - {x: -3.466667, y: -0.5008412}
-      - {x: -3.4666376, y: -0.5198595}
-    - - {x: 2.9761612, y: -0.6899626}
-      - {x: 2.9761612, y: -0.670915}
-      - {x: 2.0333335, y: -0.67094433}
-      - {x: 2.0333629, y: -0.6899626}
-    - - {x: -2.0238388, y: -0.6899626}
-      - {x: -2.0238388, y: -0.670915}
-      - {x: -2.9666667, y: -0.67094433}
-      - {x: -2.9666371, y: -0.6899626}
-    - - {x: 2.4761612, y: -0.8600658}
-      - {x: 2.4761612, y: -0.8410182}
-      - {x: 1.5333333, y: -0.8410475}
-      - {x: 1.5333626, y: -0.8600658}
-    - - {x: -1.5238388, y: -0.8600658}
-      - {x: -1.5238388, y: -0.8410182}
-      - {x: -2.4666667, y: -0.8410475}
-      - {x: -2.4666371, y: -0.8600658}
-    - - {x: 1.9761612, y: -1.0301689}
-      - {x: 1.9761612, y: -1.0111213}
-      - {x: 1.0333333, y: -1.0111506}
-      - {x: 1.0333626, y: -1.0301689}
-    - - {x: -1.0238388, y: -1.0301689}
-      - {x: -1.0238388, y: -1.0111213}
-      - {x: -1.9666666, y: -1.0111506}
-      - {x: -1.9666373, y: -1.0301689}
-    - - {x: 1.4761614, y: -1.200272}
-      - {x: 1.4761614, y: -1.1812243}
-      - {x: 0.5333333, y: -1.1812537}
-      - {x: 0.5333626, y: -1.200272}
-    - - {x: -0.5238388, y: -1.200272}
-      - {x: -0.5238388, y: -1.1812243}
-      - {x: -1.4666667, y: -1.1812537}
-      - {x: -1.4666374, y: -1.200272}
-    - - {x: 0.9761611, y: -1.370375}
-      - {x: 0.9761611, y: -1.3513274}
-      - {x: 0.0333332, y: -1.3513567}
-      - {x: 0.0333625, y: -1.370375}
-    - - {x: -0.0238388, y: -1.370375}
-      - {x: -0.0238388, y: -1.3513274}
-      - {x: -0.9666667, y: -1.3513567}
-      - {x: -0.96663743, y: -1.370375}
-  m_VertexDistance: 0.0005
-  m_OffsetDistance: 0.00005
---- !u!50 &109615039
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_BodyType: 2
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!19719996 &109615040
-TilemapCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 1
-  m_Offset: {x: 0, y: 0}
-  m_MaximumTileChangeCount: 1000
-  m_ExtrusionFactor: 0.00001
---- !u!483693784 &109615041
-TilemapRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1600035685
-  m_SortingLayer: 5
-  m_SortingOrder: 0
-  m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0.014259219, z: 0}
-  m_MaxChunkCount: 16
-  m_MaxFrameAge: 16
-  m_SortOrder: 3
-  m_Mode: 0
-  m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
---- !u!1839735485 &109615042
-Tilemap:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 109615036}
-  m_Enabled: 1
-  m_Tiles:
-  - first: {x: -4, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -3, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -2, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -1, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 0, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 1, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 2, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 3, y: -5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: -4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: -4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: -3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: -3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: -2, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: -2, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: -1, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: -1, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: 0, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 0, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: 1, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 1, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -5, y: 2, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 2, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 3, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -4, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -3, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -2, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: -1, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 0, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 1, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 2, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 3, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 4, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 5, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 3, y: 6, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 6, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 7, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 8, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 8, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 10, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 3, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 4, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  m_AnimatedTiles: {}
-  m_TileAssetArray:
-  - m_RefCount: 70
-    m_Data: {fileID: 11400000, guid: d9ad08308d8d82c4f8a077bfd6ec68b4, type: 2}
-  m_TileSpriteArray:
-  - m_RefCount: 70
-    m_Data: {fileID: 21300000, guid: bb23e60d78c4aa8438ac209fdfbb034e, type: 3}
-  m_TileMatrixArray:
-  - m_RefCount: 70
-    m_Data:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-  m_TileColorArray:
-  - m_RefCount: 70
-    m_Data: {r: 1, g: 1, b: 1, a: 1}
-  m_TileObjectToInstantiateArray: []
-  m_AnimationFrameRate: 1
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_Origin: {x: -5, y: -5, z: 0}
-  m_Size: {x: 18, y: 18, z: 1}
-  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
-  m_TileOrientation: 0
-  m_TileOrientationMatrix:
-    e00: 1
-    e01: 0
-    e02: 0
-    e03: 0
-    e10: 0
-    e11: 1
-    e12: 0
-    e13: 0
-    e20: 0
-    e21: 0
-    e22: 1
-    e23: 0
-    e30: 0
-    e31: 0
-    e32: 0
-    e33: 1
---- !u!1 &141163497
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 141163498}
-  - component: {fileID: 141163499}
-  m_Layer: 0
-  m_Name: ActivatePlatform_yellow_1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &141163498
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 141163497}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.528, y: 2.6560001, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 14
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &141163499
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 141163497}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1261725205
-  m_SortingLayer: 4
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.8509804, g: 0.75686276, b: 0.6862745, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &258850249 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1303590854}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &307939292
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 307939293}
-  - component: {fileID: 307939294}
-  m_Layer: 0
-  m_Name: ActivatePlatform_red
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &307939293
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 307939292}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.53200006, y: 2.6529999, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 13
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &307939294
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 307939292}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1261725205
-  m_SortingLayer: 4
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.91764706, g: 0.61960787, b: 0.76862746, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &370220863 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1707362408}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &444203779
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 444203780}
-  m_Layer: 0
-  m_Name: MovePlatform_green
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &444203780
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 444203779}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.10399985, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 703492822}
-  - {fileID: 1157206723}
-  - {fileID: 1751007963}
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &553443919
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 553443920}
-  - component: {fileID: 553443921}
-  - component: {fileID: 553443923}
-  - component: {fileID: 553443922}
-  m_Layer: 8
-  m_Name: ActivatePlatform_green_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &553443920
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 553443919}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.033, y: 2.823, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 12
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &553443921
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 553443919}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1261725205
-  m_SortingLayer: 4
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.6862745, g: 0.8509804, b: 0.7411765, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!60 &553443922
-PolygonCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 553443919}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.4}
-    oldSize: {x: 1.0309278, y: 1.0927835}
-    newSize: {x: 1.0309278, y: 1.0927835}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Points:
-    m_Paths:
-    - - {x: 0.0023296773, y: -0.06703494}
-      - {x: 0.31958205, y: 0.03512262}
-      - {x: -0.0009518266, y: 0.14102657}
-      - {x: -0.33601168, y: 0.0406245}
---- !u!114 &553443923
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 553443919}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9627e41f4f35cd541a8b2fc8257d5a72, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movePlatformObject: {fileID: 444203779}
---- !u!1 &618546458
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 618546459}
-  m_Layer: 0
-  m_Name: ------Single Object------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &618546459
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 618546458}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &703492821
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 703492822}
-  - component: {fileID: 703492823}
-  - component: {fileID: 703492824}
-  - component: {fileID: 703492825}
-  m_Layer: 7
-  m_Name: Platform
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &703492822
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 703492821}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.47, y: 0.07737099, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 444203780}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &703492823
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 703492821}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.6862745, g: 0.8509804, b: 0.7411765, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!114 &703492824
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 703492821}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 122080e91361a2c4182281eacb5fcd83, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  xUnit: 1
-  yUnit: 0.3402062
-  tilemap: {fileID: 1425439408}
---- !u!60 &703492825
-PolygonCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 703492821}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.4}
-    oldSize: {x: 1.0309278, y: 1.0927835}
-    newSize: {x: 1.0309278, y: 1.0927835}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Points:
-    m_Paths:
-    - - {x: 0.15864229, y: 0.03481965}
-      - {x: -0.041561604, y: 0.108747974}
-      - {x: -0.26414442, y: 0.029549247}
-      - {x: -0.048595577, y: -0.0459264}
---- !u!1 &751570946
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 751570947}
-  - component: {fileID: 751570948}
-  m_Layer: 0
-  m_Name: MovePlatform_yellow_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &751570947
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 751570946}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2.532, y: -0.37599987, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &751570948
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 751570946}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.8509804, g: 0.75686276, b: 0.6862745, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &776975817
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 776975818}
-  - component: {fileID: 776975819}
-  m_Layer: 0
-  m_Name: MovePlatform_red
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &776975818
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776975817}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.034, y: -0.20899984, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &776975819
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 776975817}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.91764706, g: 0.61960787, b: 0.76862746, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &785212918 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1303590854}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &785212922 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1303590854}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258850249}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af094f3f6be984d9d9c6cd214c515c95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &785212923
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258850249}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5bf848eb67cc74a5f905116e8aef9358, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 1425439408}
-  movingSpeed: 0.1
---- !u!1 &798842461
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 798842462}
-  - component: {fileID: 798842463}
-  - component: {fileID: 798842465}
-  - component: {fileID: 798842464}
-  m_Layer: 8
-  m_Name: ActivatePlatform_green_1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &798842462
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 798842461}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.967, y: 0.47499996, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 11
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &798842463
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 798842461}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.6862745, g: 0.8509804, b: 0.7411765, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!60 &798842464
-PolygonCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 798842461}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.4}
-    oldSize: {x: 1.0309278, y: 1.0927835}
-    newSize: {x: 1.0309278, y: 1.0927835}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Points:
-    m_Paths:
-    - - {x: 0.0023296773, y: -0.06703494}
-      - {x: 0.31958205, y: 0.03512262}
-      - {x: -0.0009518266, y: 0.14102657}
-      - {x: -0.33601168, y: 0.0406245}
---- !u!114 &798842465
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 798842461}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9627e41f4f35cd541a8b2fc8257d5a72, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movePlatformObject: {fileID: 444203779}
---- !u!1 &961739749
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 961739753}
-  - component: {fileID: 961739752}
-  - component: {fileID: 961739751}
-  - component: {fileID: 961739750}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &961739750
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961739749}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 1
-  m_Antialiasing: 1
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 1
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
---- !u!81 &961739751
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961739749}
-  m_Enabled: 1
---- !u!20 &961739752
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961739749}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 5.5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &961739753
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 961739749}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.45, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1157206722
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1157206723}
-  - component: {fileID: 1157206724}
-  m_Layer: 0
-  m_Name: Origin
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1157206723
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1157206722}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.47, y: 0.07737099, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 444203780}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1157206724
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1157206722}
-  m_Enabled: 0
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.6862745, g: 0.8509804, b: 0.7411765, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &1186764588 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5011329990471856863, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1303590854}
-  m_PrefabAsset: {fileID: 0}
---- !u!95 &1186764591
-Animator:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1186764588}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 4ce2613b8f4144bf4ba46b2a1a647395, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
---- !u!1 &1256660026
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1256660028}
-  - component: {fileID: 1256660027}
-  m_Layer: 0
-  m_Name: PlayerMode
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1256660027
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1256660026}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c6dd7f0b5c9fd4b1a9a029630356272d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  singlePlayer: 0
---- !u!4 &1256660028
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1256660026}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.5210707, y: -0.23167776, z: -0.018590745}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1268293323
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1268293324}
-  - component: {fileID: 1268293325}
-  m_Layer: 0
-  m_Name: ActivatePlatform_yellow_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1268293324
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1268293323}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.5379999, y: -0.031000108, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 15
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1268293325
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1268293323}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.8509804, g: 0.75686276, b: 0.6862745, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1001 &1303590854
+--- !u!1001 &16033804
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 2084451319}
     m_Modifications:
-    - target: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.75686276
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.68235296
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 504776237}
+    - target: {fileID: 5179123074688221405, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_Name
-      value: Character1P
+      value: ActivatePlatform_platform
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193584, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: tilemap
-      value: 
-      objectReference: {fileID: 1425439408}
-    - target: {fileID: 5011329989442193584, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: otherCharacter
-      value: 
-      objectReference: {fileID: 370220863}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 26
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.493
+      value: -0.9679999
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.01
+      value: 0.814
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: xUnit
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: yUnit
-      value: 0.3402062
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: tilemap
-      value: 
-      objectReference: {fileID: 1425439408}
-    - target: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: otherInteractor
-      value: 
-      objectReference: {fileID: 1707362413}
-    - target: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: interactableLayer.m_Bits
-      value: 1024
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193599, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: obstacleLayer.m_Bits
-      value: 64
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 0.59
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 1.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: -1198964400, guid: 85922677fb69e3641a475c12952c9ac8,
-        type: 3}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 804d7324a43877945bf5d11cd2f0b5e9, type: 3}
+--- !u!1001 &18827143
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 2470534264915310668, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_SortingLayer
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534264915310668, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_SortingLayerID
       value: -917397475
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534264915310670, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.8
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534266248434236, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.8
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.04
+      value: 0.54
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.496
+      value: -0.98
       objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856863, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304784, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_Name
+      value: Character_2P
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304794, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: otherInteractor
+      value: 
+      objectReference: {fileID: 2063741023}
+    - target: {fileID: 2470534266370304796, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 2470534266370304796, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: otherCharacter
+      value: 
+      objectReference: {fileID: 2063741017}
+    - target: {fileID: 2470534266370304797, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304799, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 7145938262029683916, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: otherInteractor
+      value: 
+      objectReference: {fileID: 2063741029}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f8af041d9e5c91b40acde3af53899501, type: 3}
+--- !u!1001 &122469079
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.675
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.6056128
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409134, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Name
+      value: HeightDetector_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409134, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
         type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6a0103c6666c8d04bbd1e684343a0a1a, type: 3}
---- !u!1 &1326444433
+  m_SourcePrefab: {fileID: 100100000, guid: fcdfbb301b719b948a71ba79bc4e9cfe, type: 3}
+--- !u!4 &122469080 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 122469079}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &126846548
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 505959569468933105, guid: d84b2efade7bd2646b2158686033e972,
+        type: 3}
+      propertyPath: m_Name
+      value: DummyNPC
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d84b2efade7bd2646b2158686033e972, type: 3}
+--- !u!4 &126846549 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
+    type: 3}
+  m_PrefabInstance: {fileID: 126846548}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &133003788
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3249,23 +506,64 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1326444435}
-  - component: {fileID: 1326444434}
-  - component: {fileID: 1326444436}
+  - component: {fileID: 133003789}
+  - component: {fileID: 133003791}
+  - component: {fileID: 133003790}
   m_Layer: 6
   m_Name: Pole2
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &1326444434
+--- !u!4 &133003789
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133003788}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.026, y: 0.109, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!68 &133003790
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133003788}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: 0.19759881, y: -0.29397494}
+  - {x: -0.029147625, y: -0.31997746}
+  - {x: -0.5568695, y: -0.14230694}
+  - {x: -0.5596285, y: -0.0421529}
+  - {x: -0.03111267, y: 0.13984066}
+  - {x: 0.2597891, y: 0.07504651}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!212 &133003791
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326444433}
+  m_GameObject: {fileID: 133003788}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -3311,93 +609,615 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!4 &1326444435
+--- !u!1001 &150655228
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.6056128
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409134, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Name
+      value: HeightDetector_yellow_2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fcdfbb301b719b948a71ba79bc4e9cfe, type: 3}
+--- !u!4 &150655229 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 150655228}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &150764153
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 150764154}
+  - component: {fileID: 150764156}
+  - component: {fileID: 150764155}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &150764154
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150764153}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 939042327}
+  m_Father: {fileID: 1161721684}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.06}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &150764155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150764153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!223 &150764156
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150764153}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: -1600035685
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!4 &185496246 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 5179123074537910888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &191256633
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 191256637}
+  - component: {fileID: 191256636}
+  - component: {fileID: 191256635}
+  - component: {fileID: 191256634}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &191256634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191256633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &191256635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191256633}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &191256636
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191256633}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &191256637
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191256633}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1623625337}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!4 &193730201 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 817565553}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &199601607
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.75686276
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074667874660, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1715205590}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[1]
+      value: 
+      objectReference: {fileID: 1821296678}
+    - target: {fileID: 5179123074688221405, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Name
+      value: ActivatePlatform_yellow_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5379999
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.032
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 804d7324a43877945bf5d11cd2f0b5e9, type: 3}
+--- !u!1 &211691174
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 211691175}
+  - component: {fileID: 211691177}
+  - component: {fileID: 211691176}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &211691175
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211691174}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594874808}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &211691176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211691174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Close
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &211691177
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211691174}
+  m_CullTransparentMesh: 1
+--- !u!1 &218104318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 218104319}
+  m_Layer: 0
+  m_Name: -----------Red Platform----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &218104319
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326444433}
+  m_GameObject: {fileID: 218104318}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.026, y: 0.109, z: 0}
+  m_LocalPosition: {x: 0.5744351, y: 2.5870008, z: -0.0515978}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2084451319}
   m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!68 &1326444436
+--- !u!1 &477395425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 477395426}
+  - component: {fileID: 477395428}
+  - component: {fileID: 477395427}
+  m_Layer: 6
+  m_Name: Pole1
+  m_TagString: Obstacle
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &477395426
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477395425}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.012, y: -0.216, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 31
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!68 &477395427
 EdgeCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326444433}
+  m_GameObject: {fileID: 477395425}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_EdgeRadius: 0
   m_Points:
-  - {x: 0.29555476, y: -0.26516438}
-  - {x: -0.5036588, y: -0.18076307}
-  - {x: -0.5106394, y: 0.0066245794}
-  - {x: 0.2597891, y: 0.07504651}
+  - {x: 0.19009733, y: -0.29908994}
+  - {x: -0.018922806, y: -0.3385632}
+  - {x: -0.52858317, y: -0.18366934}
+  - {x: -0.53963935, y: -0.059311926}
+  - {x: -0.021790624, y: 0.10431047}
+  - {x: 0.13897192, y: 0.053850397}
   m_AdjacentStartPoint: {x: 0, y: 0}
   m_AdjacentEndPoint: {x: 0, y: 0}
   m_UseAdjacentStartPoint: 0
   m_UseAdjacentEndPoint: 0
---- !u!1 &1425439405
-GameObject:
+--- !u!212 &477395428
+SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1425439406}
-  - component: {fileID: 1425439408}
-  - component: {fileID: 1425439407}
-  m_Layer: 0
-  m_Name: Floor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1425439406
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1425439405}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.03, y: -4.1, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!483693784 &1425439407
-TilemapRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1425439405}
+  m_GameObject: {fileID: 477395425}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
   m_MotionVectors: 1
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
@@ -3421,810 +1241,21 @@ TilemapRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1340146497
-  m_SortingLayer: 1
-  m_SortingOrder: 1
-  m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0.015463889, y: 0.046391726, z: 0}
-  m_MaxChunkCount: 16
-  m_MaxFrameAge: 16
-  m_SortOrder: 3
-  m_Mode: 0
-  m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
---- !u!1839735485 &1425439408
-Tilemap:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1425439405}
-  m_Enabled: 1
-  m_Tiles:
-  - first: {x: 5, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 11, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 12, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 13, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 14, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 15, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 16, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 17, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 5, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 6, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 7, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 8, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 9, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 10, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 11, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  - first: {x: 12, y: 18, z: 0}
-    second:
-      serializedVersion: 2
-      m_TileIndex: 0
-      m_TileSpriteIndex: 0
-      m_TileMatrixIndex: 0
-      m_TileColorIndex: 0
-      m_TileObjectToInstantiateIndex: 65535
-      dummyAlignment: 0
-      m_AllTileFlags: 1073741825
-  m_AnimatedTiles: {}
-  m_TileAssetArray:
-  - m_RefCount: 64
-    m_Data: {fileID: 11400000, guid: a39da0b1e35378f45984a370118797de, type: 2}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  m_TileSpriteArray:
-  - m_RefCount: 64
-    m_Data: {fileID: 21300000, guid: 857b3e827441f5044ada64334f8f4558, type: 3}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  m_TileMatrixArray:
-  - m_RefCount: 64
-    m_Data:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-  m_TileColorArray:
-  - m_RefCount: 64
-    m_Data: {r: 1, g: 1, b: 1, a: 1}
-  - m_RefCount: 0
-    m_Data: {r: 3.827e-41, g: 3.827e-41, b: 3.827e-41, a: 3.827e-41}
-  m_TileObjectToInstantiateArray: []
-  m_AnimationFrameRate: 1
+  m_SortingLayerID: -917397475
+  m_SortingLayer: 3
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 97f61a0d55c8ec2439d5bf898b67966a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: 0, y: 0, z: 0}
-  m_Size: {x: 22, y: 28, z: 9}
-  m_TileAnchor: {x: -0.5, y: -0.5, z: 0}
-  m_TileOrientation: 0
-  m_TileOrientationMatrix:
-    e00: 1
-    e01: 0
-    e02: 0
-    e03: 0
-    e10: 0
-    e11: 1
-    e12: 0
-    e13: 0
-    e20: 0
-    e21: 0
-    e22: 1
-    e23: 0
-    e30: 0
-    e31: 0
-    e32: 0
-    e33: 1
---- !u!1 &1451406879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1451406880}
-  - component: {fileID: 1451406881}
-  m_Layer: 0
-  m_Name: Objective
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1451406880
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1451406879}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.532, y: 1.9819999, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 18
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1451406881
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1451406879}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1261725205
-  m_SortingLayer: 4
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.9411765, g: 0.9411765, b: 0.9411765, a: 1}
-  m_FlipX: 0
+  m_FlipX: 1
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
+  m_Size: {x: 1.2, y: 1.2}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1502114860
+--- !u!1 &487600234
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4232,83 +1263,98 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1502114861}
-  - component: {fileID: 1502114862}
-  m_Layer: 0
-  m_Name: AccessButton
+  - component: {fileID: 487600235}
+  - component: {fileID: 487600238}
+  - component: {fileID: 487600237}
+  - component: {fileID: 487600236}
+  m_Layer: 5
+  m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1502114861
-Transform:
+  m_IsActive: 0
+--- !u!224 &487600235
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502114860}
+  m_GameObject: {fileID: 487600234}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.96899986, y: 1.8039999, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 17
+  m_Children:
+  - {fileID: 613286741}
+  - {fileID: 594874808}
+  m_Father: {fileID: 1623625337}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1502114862
-SpriteRenderer:
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!95 &487600236
+Animator:
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502114860}
+  m_GameObject: {fileID: 487600234}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1261725205
-  m_SortingLayer: 4
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.76862746, g: 0.76862746, b: 0.76862746, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &1678283527
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 6088c312eb343974aa13057038ab7ffe, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &487600237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 487600234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3773585, g: 0.3773585, b: 0.3773585, a: 0.92156863}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &487600238
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 487600234}
+  m_CullTransparentMesh: 1
+--- !u!1 &490090049
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4316,9 +1362,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1678283528}
-  - component: {fileID: 1678283530}
-  - component: {fileID: 1678283529}
+  - component: {fileID: 490090050}
+  - component: {fileID: 490090052}
+  - component: {fileID: 490090051}
   m_Layer: 0
   m_Name: Wall
   m_TagString: Untagged
@@ -4326,13 +1372,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1678283528
+--- !u!4 &490090050
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678283527}
+  m_GameObject: {fileID: 490090049}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 3.03, y: -4.1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -4341,13 +1387,13 @@ Transform:
   m_Father: {fileID: 2084451319}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!483693784 &1678283529
+--- !u!483693784 &490090051
 TilemapRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678283527}
+  m_GameObject: {fileID: 490090049}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -4390,13 +1436,13 @@ TilemapRenderer:
   m_Mode: 1
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
---- !u!1839735485 &1678283530
+--- !u!1839735485 &490090052
 Tilemap:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678283527}
+  m_GameObject: {fileID: 490090049}
   m_Enabled: 1
   m_Tiles:
   - first: {x: 15, y: 13, z: 0}
@@ -5256,245 +2302,19 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!1001 &1707362408
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 2084451319}
-    m_Modifications:
-    - target: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Name
-      value: Character2P
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193574, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193584, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: tilemap
-      value: 
-      objectReference: {fileID: 1425439408}
-    - target: {fileID: 5011329989442193584, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: otherCharacter
-      value: 
-      objectReference: {fileID: 258850249}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.183
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: xUnit
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: yUnit
-      value: 0.3402062
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193594, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: tilemap
-      value: 
-      objectReference: {fileID: 1425439408}
-    - target: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: otherInteractor
-      value: 
-      objectReference: {fileID: 785212922}
-    - target: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: interactableLayer.m_Bits
-      value: 1024
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193597, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_DefaultActionMap
-      value: 9b729fff-b789-4f26-a115-a2cae43e047c
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329989442193599, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: obstacleLayer.m_Bits
-      value: 64
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 0.79
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 1.56
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 1164501676, guid: b471ac0d5892c0746b87c773bc704cf7,
-        type: 3}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_SortingLayer
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856849, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_SortingLayerID
-      value: -917397475
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.032
-      objectReference: {fileID: 0}
-    - target: {fileID: 5011329990471856862, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.524
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6a0103c6666c8d04bbd1e684343a0a1a, type: 3}
---- !u!4 &1707362409 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193592, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1707362408}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1707362413 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5011329989442193596, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1707362408}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370220863}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af094f3f6be984d9d9c6cd214c515c95, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1707362414
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370220863}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5bf848eb67cc74a5f905116e8aef9358, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 1425439408}
-  movingSpeed: 0.1
---- !u!1 &1729040699 stripped
+--- !u!1 &504776237 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 5011329990471856863, guid: 6a0103c6666c8d04bbd1e684343a0a1a,
+  m_CorrespondingSourceObject: {fileID: 7439722824400337146, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
     type: 3}
-  m_PrefabInstance: {fileID: 1707362408}
+  m_PrefabInstance: {fileID: 3700762156170515984}
   m_PrefabAsset: {fileID: 0}
---- !u!95 &1729040702
-Animator:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!4 &527188123 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 16033804}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1729040699}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 0f333b28e8de545e4aeb6ff7a08bf5fa, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorControllerStateOnDisable: 0
---- !u!1 &1751007962
+--- !u!1 &543814633
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5502,40 +2322,41 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1751007963}
-  - component: {fileID: 1751007964}
+  - component: {fileID: 543814634}
+  - component: {fileID: 543814636}
+  - component: {fileID: 543814635}
   m_Layer: 0
-  m_Name: Target
+  m_Name: Mask
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1751007963
+--- !u!4 &543814634
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1751007962}
+  m_GameObject: {fileID: 543814633}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.47, y: 2.697, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 0.036, z: 0}
+  m_LocalScale: {x: 1, y: 1.1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 444203780}
-  m_RootOrder: 2
+  m_Father: {fileID: 1503894989}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1751007964
-SpriteRenderer:
+--- !u!331 &543814635
+SpriteMask:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1751007962}
-  m_Enabled: 0
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
+  m_GameObject: {fileID: 543814633}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
   m_MotionVectors: 1
@@ -5543,10 +2364,10 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
+  m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -5559,65 +2380,32 @@ SpriteRenderer:
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
   m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.6862745, g: 0.8509804, b: 0.7411765, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 1b4ab19270f10a443850e70d28f6c708, type: 3}
+  m_MaskAlphaCutoff: 0.2
+  m_FrontSortingLayerID: -1261725205
+  m_BackSortingLayerID: -1261725205
+  m_FrontSortingLayer: 4
+  m_BackSortingLayer: 4
+  m_FrontSortingOrder: 100
+  m_BackSortingOrder: -100
+  m_IsCustomRangeActive: 1
   m_SpriteSortPoint: 0
---- !u!1 &1751928564
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1751928565}
-  - component: {fileID: 1751928566}
-  m_Layer: 0
-  m_Name: MovePlatform_blue
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1751928565
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1751928564}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.035000056, y: 3.795, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1751928566
+--- !u!212 &543814636
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1751928564}
-  m_Enabled: 1
+  m_GameObject: {fileID: 543814633}
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -5651,7 +2439,7 @@ SpriteRenderer:
   m_SortingLayerID: -1261725205
   m_SortingLayer: 4
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 1b4ab19270f10a443850e70d28f6c708, type: 3}
   m_Color: {r: 0.68235296, g: 0.75686276, b: 0.8509804, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -5662,7 +2450,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1759387011
+--- !u!1 &594874807
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5670,198 +2458,133 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1759387012}
-  m_Layer: 0
-  m_Name: ----Tilemap------
+  - component: {fileID: 594874808}
+  - component: {fileID: 594874811}
+  - component: {fileID: 594874810}
+  - component: {fileID: 594874809}
+  m_Layer: 5
+  m_Name: Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1759387012
-Transform:
+--- !u!224 &594874808
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1759387011}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 594874807}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 0
+  m_Children:
+  - {fileID: 211691175}
+  m_Father: {fileID: 487600235}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1766550507
-GameObject:
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 180, y: -90}
+  m_SizeDelta: {x: 80, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &594874809
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1766550508}
-  - component: {fileID: 1766550509}
-  m_Layer: 0
-  m_Name: ActivatePlatform_blue
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1766550508
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1766550507}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.96799994, y: 0.81099993, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1766550509
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1766550507}
+  m_GameObject: {fileID: 594874807}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.68235296, g: 0.75686276, b: 0.8509804, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &1801806158
-GameObject:
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 594874810}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1623625338}
+        m_TargetAssemblyTypeName: Notification, Assembly-CSharp
+        m_MethodName: CloseNotification
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &594874810
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1801806159}
-  - component: {fileID: 1801806160}
-  m_Layer: 0
-  m_Name: MovePlatform_yellow_1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1801806159
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801806158}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.467, y: 0.30399996, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2084451319}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1801806160
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801806158}
+  m_GameObject: {fileID: 594874807}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -2090849061
-  m_SortingLayer: 2
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
-  m_Color: {r: 0.8509804, g: 0.75686276, b: 0.6862745, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0309278, y: 1.0927835}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &1835482282
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &594874811
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594874807}
+  m_CullTransparentMesh: 1
+--- !u!1 &604132974
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5869,23 +2592,23 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1835482283}
-  - component: {fileID: 1835482285}
-  - component: {fileID: 1835482284}
+  - component: {fileID: 604132975}
+  - component: {fileID: 604132977}
+  - component: {fileID: 604132976}
   m_Layer: 0
-  m_Name: FloatPlatform
+  m_Name: RaisedPlatform
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1835482283
+--- !u!4 &604132975
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835482282}
+  m_GameObject: {fileID: 604132974}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 3.03, y: -4.1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -5894,13 +2617,13 @@ Transform:
   m_Father: {fileID: 2084451319}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!483693784 &1835482284
+--- !u!483693784 &604132976
 TilemapRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835482282}
+  m_GameObject: {fileID: 604132974}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -5940,16 +2663,16 @@ TilemapRenderer:
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 3
-  m_Mode: 0
+  m_Mode: 1
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
---- !u!1839735485 &1835482285
+--- !u!1839735485 &604132977
 Tilemap:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835482282}
+  m_GameObject: {fileID: 604132974}
   m_Enabled: 1
   m_Tiles:
   - first: {x: 16, y: 19, z: 0}
@@ -6205,7 +2928,7 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!1 &1849268496
+--- !u!1 &613286738
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6213,23 +2936,1222 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1849268498}
-  - component: {fileID: 1849268497}
-  - component: {fileID: 1849268499}
-  m_Layer: 6
-  m_Name: Pole1
+  - component: {fileID: 613286741}
+  - component: {fileID: 613286740}
+  - component: {fileID: 613286739}
+  m_Layer: 5
+  m_Name: Message
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &1849268497
+--- !u!114 &613286739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613286738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 4
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &613286740
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613286738}
+  m_CullTransparentMesh: 1
+--- !u!224 &613286741
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613286738}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 487600235}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &731533929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 731533930}
+  m_Layer: 0
+  m_Name: ---------Characters----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &731533930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 731533929}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.57216287, y: 4.6860275, z: -0.05540385}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &817565553
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.7411765
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177529, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 6081139256600177531, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: heightDetector
+      value: 
+      objectReference: {fileID: 1238002324}
+    - target: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Name
+      value: MovePlatform_green
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.032
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256876201328, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8164be588fb25d549b8dfcfc4609f1b1, type: 3}
+--- !u!4 &821922301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 199601607}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &835477586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 1068218977782434180, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218977782434180, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218977782434181, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_SortingLayer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218977782434181, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: -917397475
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808900, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Name
+      value: Character_1P
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.967
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.172
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245808902, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 1068218978245808902, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: movingSpeed
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 0.19321382
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 0.071514234
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -0.011879265
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809016, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: -0.0009107068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068218978245809017, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 1068218978245809017, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: otherCharacter
+      value: 
+      objectReference: {fileID: 1097655420}
+    - target: {fileID: 1068218978245809019, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: otherInteractor
+      value: 
+      objectReference: {fileID: 1097655427}
+    - target: {fileID: 1068218979012799797, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807749665105663781, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: otherInteractor
+      value: 
+      objectReference: {fileID: 1097655428}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd098490cc6c7d04492ac7c08e506340, type: 3}
+--- !u!4 &836803926 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 861931078}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &850064038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1824976653}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.76862746
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.61960787
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.91764706
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025937, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Name
+      value: ActivatePlatform_raised
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.53200006
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.654
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c42903ead897beb4f9f98b1568c3cb53, type: 3}
+--- !u!4 &855447665 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1547749426}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &861931078
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.75686276
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177529, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 6081139256600177531, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: heightDetector
+      value: 
+      objectReference: {fileID: 1810778166}
+    - target: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Name
+      value: MovePlatform_yellow_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.501
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8164be588fb25d549b8dfcfc4609f1b1, type: 3}
+--- !u!1 &896176740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 896176741}
+  m_Layer: 0
+  m_Name: ---------Blue Platform----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &896176741
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896176740}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.5744351, y: 2.5870008, z: -0.0515978}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &918210121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 918210122}
+  - component: {fileID: 918210123}
+  m_Layer: 0
+  m_Name: NormalSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &918210122
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918210121}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1503894989}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &918210123
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1849268496}
+  m_GameObject: {fileID: 918210121}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1261725205
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 226f9d9e0ffd47348b69dc52d2a62d73, type: 3}
+  m_Color: {r: 0.76862746, g: 0.76862746, b: 0.76862746, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.0309278, y: 1.0927835}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 2
+  m_SpriteSortPoint: 1
+--- !u!1 &939042326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 939042327}
+  m_Layer: 5
+  m_Name: PlaceHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &939042327
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939042326}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1537841782}
+  - {fileID: 1544696759}
+  m_Father: {fileID: 150764154}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &961739749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 961739753}
+  - component: {fileID: 961739752}
+  - component: {fileID: 961739751}
+  - component: {fileID: 961739750}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &961739750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 1
+  m_Antialiasing: 1
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 1
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!81 &961739751
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+--- !u!20 &961739752
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5.5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &961739753
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.45, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1063425493 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+    type: 3}
+  m_PrefabInstance: {fileID: 2066823331}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1097655420 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2470534266370304784, guid: f8af041d9e5c91b40acde3af53899501,
+    type: 3}
+  m_PrefabInstance: {fileID: 18827143}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1097655421 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2470534266370304773, guid: f8af041d9e5c91b40acde3af53899501,
+    type: 3}
+  m_PrefabInstance: {fileID: 18827143}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1097655427 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2470534266370304794, guid: f8af041d9e5c91b40acde3af53899501,
+    type: 3}
+  m_PrefabInstance: {fileID: 18827143}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097655420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af094f3f6be984d9d9c6cd214c515c95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1097655428 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7145938262029683916, guid: f8af041d9e5c91b40acde3af53899501,
+    type: 3}
+  m_PrefabInstance: {fileID: 18827143}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097655420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b64ac922449503740a905da9fc71e443, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1097655429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097655420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb406fdbecaaa4831b72ebcdc806a9e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UDCollider: {fileID: 1097655431}
+  LRCollider: {fileID: 1097655430}
+--- !u!68 &1097655430
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097655420}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.2362243, y: 0.048856795}
+  - {x: 0.22232068, y: -0.111071765}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!68 &1097655431
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097655420}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.2858357, y: -0.11552554}
+  - {x: 0.18592966, y: 0.044867218}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!1 &1161721683
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1161721684}
+  - component: {fileID: 1161721688}
+  - component: {fileID: 1161721687}
+  - component: {fileID: 1161721686}
+  - component: {fileID: 1161721685}
+  m_Layer: 10
+  m_Name: CheckObjectiveTile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1161721684
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161721683}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.04, y: -1.204, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 150764154}
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 30
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!68 &1161721685
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161721683}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.24306408, y: 0.029137611}
+  - {x: 0.2008416, y: 0.03273928}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!114 &1161721686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161721683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d63c1bda491d8641b42f67d9f366250, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ItemsNeeded: 00000000
+--- !u!114 &1161721687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161721683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 073797afb82c5a1438f328866b10b3f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ComponentVersion: 1
+  m_LightType: 1
+  m_BlendStyleIndex: 0
+  m_FalloffIntensity: 0.834
+  m_Color: {r: 0, g: 0.08152612, b: 0.93333334, a: 1}
+  m_Intensity: 25.96
+  m_LightVolumeIntensity: 1
+  m_LightVolumeIntensityEnabled: 0
+  m_ApplyToSortingLayers: 00000000bffc1eb0db2c60831da051c9eb99cbb49b64a1a0
+  m_LightCookieSprite: {fileID: 21300000, guid: b74585b0504d270408aeb6e1a207642a,
+    type: 3}
+  m_DeprecatedPointLightCookieSprite: {fileID: 0}
+  m_LightOrder: 0
+  m_AlphaBlendOnOverlap: 0
+  m_OverlapOperation: 0
+  m_NormalMapDistance: 3
+  m_NormalMapQuality: 2
+  m_UseNormalMap: 0
+  m_ShadowIntensityEnabled: 0
+  m_ShadowIntensity: 0.512
+  m_ShadowVolumeIntensityEnabled: 0
+  m_ShadowVolumeIntensity: 0.75
+  m_Vertices:
+  - position: {x: -0.022607453, y: -0.15389049, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.022030976, y: 0.18082735, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.45812786, y: 0.016431406, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.53553694, y: 0.016740397, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.022607453, y: -0.15389049, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.45812786, y: 0.016431406, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.022030976, y: 0.18082735, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.53553694, y: 0.016740397, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 1}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.0952, y: -0.3721, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.0299, y: -0.3837, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.0542, y: -0.3706, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.5349, y: -0.2004, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.5935, y: -0.1695, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6409, y: -0.1232, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6731, y: -0.0653, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6875, y: -0.0006, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6828, y: 0.0656, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6594, y: 0.1276, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.6194, y: 0.1804, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.5659, y: 0.2196, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.5326, y: 0.234, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: 0.0525, y: 0.3984, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.0126, y: 0.4106, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.092, y: 0.3999, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.6055, y: 0.2358, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.6651, y: 0.2067, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7139, y: 0.1619, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7479, y: 0.105, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7642, y: 0.0408, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7616, y: -0.0255, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7402, y: -0.0882, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.7018, y: -0.1422, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.6496, y: -0.183, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  - position: {x: -0.6081, y: -0.2016, z: 0}
+    color: {r: 0, g: 0, b: 0, a: 0}
+    uv: {x: 0, y: 0}
+  m_Triangles: 000001000200010000000300040008000800040008000900040009000a00040005000b0004000a000b0005000b000c0005000c000d0005000d000e0005000e000f0005000f001000050010001100050011001200050012001300050013001400050006001500050014001500060015001600060016001700060007001800060017001800070018001900070019001a0007001a001b0007001b001c0007001c001d0007001d001e0007001e001f0007001f002000070020002100080004000700080021000700
+  m_LocalBounds:
+    m_Center: {x: -0.038349986, y: 0.013449997, z: 0}
+    m_Extent: {x: 0.72585, y: 0.39715, z: 0}
+  m_PointLightInnerAngle: 360
+  m_PointLightOuterAngle: 360
+  m_PointLightInnerRadius: 0
+  m_PointLightOuterRadius: 1
+  m_ShapeLightParametricSides: 5
+  m_ShapeLightParametricAngleOffset: 0
+  m_ShapeLightParametricRadius: 1
+  m_ShapeLightFalloffSize: 0.23
+  m_ShapeLightFalloffOffset: {x: 0, y: 0}
+  m_ShapePath:
+  - {x: -0.022607453, y: -0.15389049, z: 0}
+  - {x: 0.45812786, y: 0.016431406, z: 0}
+  - {x: -0.022030976, y: 0.18082735, z: 0}
+  - {x: -0.53553694, y: 0.016740397, z: 0}
+--- !u!212 &1161721688
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161721683}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -6264,56 +4186,3799 @@ SpriteRenderer:
   m_SortingLayerID: -917397475
   m_SortingLayer: 3
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 97f61a0d55c8ec2439d5bf898b67966a, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b74585b0504d270408aeb6e1a207642a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
+  m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.2, y: 1.2}
+  m_Size: {x: 1.0309278, y: 1.0927835}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!4 &1849268498
+--- !u!4 &1171668764 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+    type: 3}
+  m_PrefabInstance: {fileID: 850064038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!68 &1238002324 stripped
+EdgeCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 122469079}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1241649407
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1241649408}
+  m_Layer: 0
+  m_Name: ----------Green Platform-----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1241649408
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1849268496}
+  m_GameObject: {fileID: 1241649407}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2.012, y: -0.216, z: 0}
+  m_LocalPosition: {x: 0.5744351, y: 2.5870008, z: -0.0515978}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2084451319}
-  m_RootOrder: 19
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!68 &1849268499
+--- !u!1 &1256660026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1256660028}
+  - component: {fileID: 1256660027}
+  m_Layer: 0
+  m_Name: PlayerMode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1256660027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256660026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6dd7f0b5c9fd4b1a9a029630356272d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  singlePlayer: 1
+--- !u!4 &1256660028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1256660026}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.5210707, y: -0.23167776, z: -0.018590745}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1269660207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1269660208}
+  m_Layer: 0
+  m_Name: Pressed
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1269660208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269660207}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.056, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1503894989}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1270060327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1270060328}
+  m_Layer: 0
+  m_Name: ----Debugging------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1270060328
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1270060327}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.012, y: -0.21600002, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1382893552
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.479
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.037
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.6056128
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409134, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Name
+      value: HeightDetector_yellow_1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fcdfbb301b719b948a71ba79bc4e9cfe, type: 3}
+--- !u!4 &1382893553 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 1382893552}
+  m_PrefabAsset: {fileID: 0}
+--- !u!68 &1382893554 stripped
+EdgeCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 1382893552}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1389574067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1389574068}
+  - component: {fileID: 1389574071}
+  - component: {fileID: 1389574070}
+  - component: {fileID: 1389574069}
+  m_Layer: 10
+  m_Name: Objective
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1389574068
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389574067}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.538, y: 2.015, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 29
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!68 &1389574069
 EdgeCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1849268496}
+  m_GameObject: {fileID: 1389574067}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_EdgeRadius: 0
   m_Points:
-  - {x: 0.29584146, y: -0.2932153}
-  - {x: -0.47926283, y: -0.19119735}
-  - {x: -0.490319, y: -0.008831799}
-  - {x: 0.2579428, y: 0.07495712}
+  - {x: -0.2923381, y: 0.0131031275}
+  - {x: 0.24901345, y: 0.0071974993}
   m_AdjacentStartPoint: {x: 0, y: 0}
   m_AdjacentEndPoint: {x: 0, y: 0}
   m_UseAdjacentStartPoint: 0
   m_UseAdjacentEndPoint: 0
+--- !u!114 &1389574070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389574067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d639d82bfd4ef74b9796a4207d216e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ItemsIDList: 00000000
+  ItemSprite: {fileID: 1389574071}
+--- !u!212 &1389574071
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389574067}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1261725205
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 8ca5b4d6a78912a43b0b0d5e2f90ec6e, type: 3}
+  m_Color: {r: 0.9411765, g: 0.9411765, b: 0.9411765, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.0309278, y: 1.0927835}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 1
+--- !u!1 &1503894988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1503894989}
+  - component: {fileID: 1503894992}
+  - component: {fileID: 1503894991}
+  - component: {fileID: 1503894990}
+  m_Layer: 10
+  m_Name: RemovalButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1503894989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503894988}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.96899986, y: 1.81, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 918210122}
+  - {fileID: 2107578599}
+  - {fileID: 1269660208}
+  - {fileID: 543814634}
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 28
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1503894990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503894988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68a915e45b4e73f45affa5af5c8df363, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TargetsToRemove:
+  - {fileID: 477395425}
+  - {fileID: 133003788}
+  RemoveMethod: 0
+--- !u!114 &1503894991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503894988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f97c0bdd5529269468618a5bc5c018eb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsAligned: 0
+  VerticalOffset: 0.0555
+  HorizontalOffset: 0
+  sprite: {fileID: 918210121}
+  Raised: {fileID: 2107578599}
+  Pressed: {fileID: 1269660208}
+  pressingSpeed: 0.01
+  buttonType: 0
+--- !u!60 &1503894992
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503894988}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.4}
+    oldSize: {x: 1.0309278, y: 1.0927835}
+    newSize: {x: 1.0309278, y: 1.0927835}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.0023296773, y: 0.028454296}
+      - {x: 0.17634815, y: 0.09719066}
+      - {x: -0.0009518266, y: 0.16967334}
+      - {x: -0.16413096, y: 0.09075636}
+--- !u!4 &1520996010 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+    type: 3}
+  m_PrefabInstance: {fileID: 4958872824416002808}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1537841781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1537841782}
+  - component: {fileID: 1537841784}
+  - component: {fileID: 1537841783}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1537841782
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1537841781}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 939042327}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.887}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1537841783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1537841781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Bring Objective to here
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22.05
+  m_fontSizeBase: 10
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1537841784
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1537841781}
+  m_CullTransparentMesh: 1
+--- !u!1 &1544696758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1544696759}
+  - component: {fileID: 1544696761}
+  - component: {fileID: 1544696760}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1544696759
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544696758}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 939042327}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.24}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1544696760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544696758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c80447f61e1279a4fad12131b3727aba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1544696761
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544696758}
+  m_CullTransparentMesh: 1
+--- !u!1001 &1547749426
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 6081139256600177529, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 6081139256600177531, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: heightDetector
+      value: 
+      objectReference: {fileID: 2069284872}
+    - target: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Name
+      value: MovePlatform_red
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.034
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.20899984
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8164be588fb25d549b8dfcfc4609f1b1, type: 3}
+--- !u!1 &1568558542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1568558545}
+  - component: {fileID: 1568558543}
+  - component: {fileID: 1568558544}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1839735485 &1568558543
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568558542}
+  m_Enabled: 1
+  m_Tiles:
+  - first: {x: 5, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 13, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 14, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 15, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 16, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 17, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 18, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  m_AnimatedTiles: {}
+  m_TileAssetArray:
+  - m_RefCount: 64
+    m_Data: {fileID: 11400000, guid: a39da0b1e35378f45984a370118797de, type: 2}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileSpriteArray:
+  - m_RefCount: 64
+    m_Data: {fileID: 21300000, guid: 857b3e827441f5044ada64334f8f4558, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileMatrixArray:
+  - m_RefCount: 64
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 64
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  - m_RefCount: 0
+    m_Data: {r: 3.827e-41, g: 3.827e-41, b: 3.827e-41, a: 3.827e-41}
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 22, y: 28, z: 9}
+  m_TileAnchor: {x: -0.5, y: -0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!483693784 &1568558544
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568558542}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1340146497
+  m_SortingLayer: 1
+  m_SortingOrder: 1
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0.015463889, y: 0.046391726, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 3
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!4 &1568558545
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568558542}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.03, y: -4.1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1623625336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1623625337}
+  - component: {fileID: 1623625338}
+  m_Layer: 5
+  m_Name: Notification
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1623625337
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623625336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 487600235}
+  m_Father: {fileID: 191256637}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -1400, y: -800}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1623625338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623625336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de437cdf5305a57439db81fee0b766b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Animator: {fileID: 487600236}
+  closeAnimation: {fileID: 7400000, guid: 500c9bf0a56a8ca47894b2e2e08c4455, type: 2}
+  Message: {fileID: 613286739}
+  Visual: {fileID: 487600234}
+--- !u!1 &1715205590 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2119476458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1755834168 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 817565553}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1759387011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1759387012}
+  m_Layer: 0
+  m_Name: ----Tilemap------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1759387012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1759387011}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1762346264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1762346265}
+  - component: {fileID: 1762346270}
+  - component: {fileID: 1762346269}
+  - component: {fileID: 1762346268}
+  - component: {fileID: 1762346267}
+  - component: {fileID: 1762346266}
+  m_Layer: 6
+  m_Name: Obstacle
+  m_TagString: Obstacle
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1762346265
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!66 &1762346266
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 1762346268}
+    m_ColliderPaths:
+    - - X: -238095
+        Y: 40919712
+      - X: -9666667
+        Y: 40919712
+      - X: -9666667
+        Y: 40729236
+      - X: -238095
+        Y: 40729236
+    - - X: 9761904
+        Y: 40919712
+      - X: 333332
+        Y: 40919712
+      - X: 333332
+        Y: 40729236
+      - X: 9761904
+        Y: 40729236
+    - - X: -5238095
+        Y: 39218684
+      - X: -14666667
+        Y: 39218684
+      - X: -14666667
+        Y: 39028204
+      - X: -5238095
+        Y: 39028204
+    - - X: 9762004
+        Y: 37327135
+      - X: 9762004
+        Y: 37517693
+      - X: 9761945
+        Y: 37517752
+      - X: 333291
+        Y: 37517752
+      - X: 333232
+        Y: 37517693
+      - X: 333232
+        Y: 37327135
+      - X: 333291
+        Y: 37327076
+      - X: 9761945
+        Y: 37327076
+    - - X: -10238094
+        Y: 37517652
+      - X: -19666666
+        Y: 37517652
+      - X: -19666666
+        Y: 37327176
+      - X: -10238094
+        Y: 37327176
+    - - X: -15238094
+        Y: 35816620
+      - X: -24666666
+        Y: 35816620
+      - X: -24666666
+        Y: 35626144
+      - X: -15238094
+        Y: 35626144
+    - - X: 4761905
+        Y: 35816620
+      - X: -4666667
+        Y: 35816620
+      - X: -4666667
+        Y: 35626144
+      - X: 4761905
+        Y: 35626144
+    - - X: 19762006
+        Y: 33925071
+      - X: 19762006
+        Y: 34115633
+      - X: 19761947
+        Y: 34115692
+      - X: 10333292
+        Y: 34115692
+      - X: 10333233
+        Y: 34115633
+      - X: 10333233
+        Y: 33925071
+      - X: 10333292
+        Y: 33925012
+      - X: 19761947
+        Y: 33925012
+    - - X: -20238094
+        Y: 34115592
+      - X: -29666666
+        Y: 34115592
+      - X: -29666666
+        Y: 33925112
+      - X: -20238094
+        Y: 33925112
+    - - X: 29761906
+        Y: 34115592
+      - X: 20333334
+        Y: 34115592
+      - X: 20333334
+        Y: 33925112
+      - X: 29761906
+        Y: 33925112
+    - - X: -238095
+        Y: 34115592
+      - X: -9666667
+        Y: 34115592
+      - X: -9666667
+        Y: 33925112
+      - X: -238095
+        Y: 33925112
+    - - X: 4762005
+        Y: 32224041
+      - X: 4762005
+        Y: 32414601
+      - X: 4761946
+        Y: 32414660
+      - X: -4666708
+        Y: 32414660
+      - X: -4666767
+        Y: 32414601
+      - X: -4666767
+        Y: 32224041
+      - X: -4666708
+        Y: 32223982
+      - X: 4761946
+        Y: 32223982
+    - - X: -25238094
+        Y: 32414560
+      - X: -34666668
+        Y: 32414560
+      - X: -34666668
+        Y: 32224082
+      - X: -25238094
+        Y: 32224082
+    - - X: 34761904
+        Y: 32414560
+      - X: 25333334
+        Y: 32414560
+      - X: 25333334
+        Y: 32224082
+      - X: 34761904
+        Y: 32224082
+    - - X: -30238094
+        Y: 30713530
+      - X: -39666668
+        Y: 30713530
+      - X: -39666668
+        Y: 30523052
+      - X: -30238094
+        Y: 30523052
+    - - X: 39761904
+        Y: 30713530
+      - X: 30333334
+        Y: 30713530
+      - X: 30333334
+        Y: 30523052
+      - X: 39761904
+        Y: 30523052
+    - - X: 19761906
+        Y: 30713530
+      - X: 10333333
+        Y: 30713530
+      - X: 10333333
+        Y: 30523052
+      - X: 19761906
+        Y: 30523052
+    - - X: -10238094
+        Y: 30713530
+      - X: -19666666
+        Y: 30713530
+      - X: -19666666
+        Y: 30523052
+      - X: -10238094
+        Y: 30523052
+    - - X: 9761904
+        Y: 30713530
+      - X: 333332
+        Y: 30713530
+      - X: 333332
+        Y: 30523052
+      - X: 9761904
+        Y: 30523052
+    - - X: -5237995
+        Y: 28821981
+      - X: -5237995
+        Y: 29012539
+      - X: -5238054
+        Y: 29012598
+      - X: -14666708
+        Y: 29012598
+      - X: -14666767
+        Y: 29012539
+      - X: -14666767
+        Y: 28821981
+      - X: -14666708
+        Y: 28821922
+      - X: -5238054
+        Y: 28821922
+    - - X: -35238096
+        Y: 29012498
+      - X: -44666668
+        Y: 29012498
+      - X: -44666668
+        Y: 28822022
+      - X: -35238096
+        Y: 28822022
+    - - X: -15238094
+        Y: 29012498
+      - X: -24666666
+        Y: 29012498
+      - X: -24666666
+        Y: 28822022
+      - X: -15238094
+        Y: 28822022
+    - - X: 14761906
+        Y: 29012498
+      - X: 5333333
+        Y: 29012498
+      - X: 5333333
+        Y: 28822022
+      - X: 14761906
+        Y: 28822022
+    - - X: -20238094
+        Y: 27311468
+      - X: -29666666
+        Y: 27311468
+      - X: -29666666
+        Y: 27120990
+      - X: -20238094
+        Y: 27120990
+    - - X: -238095
+        Y: 27311468
+      - X: -9666667
+        Y: 27311468
+      - X: -9666667
+        Y: 27120990
+      - X: -238095
+        Y: 27120990
+    - - X: 39761904
+        Y: 27311468
+      - X: 30333334
+        Y: 27311468
+      - X: 30333334
+        Y: 27120990
+      - X: 39761904
+        Y: 27120990
+    - - X: 29761906
+        Y: 27311468
+      - X: 20333334
+        Y: 27311468
+      - X: 20333334
+        Y: 27120990
+      - X: 29761906
+        Y: 27120990
+    - - X: 34762004
+        Y: 25419919
+      - X: 34762004
+        Y: 25610479
+      - X: 34761945
+        Y: 25610538
+      - X: 25333293
+        Y: 25610538
+      - X: 25333234
+        Y: 25610479
+      - X: 25333234
+        Y: 25419919
+      - X: 25333293
+        Y: 25419860
+      - X: 34761945
+        Y: 25419860
+    - - X: -35238096
+        Y: 25610438
+      - X: -44666668
+        Y: 25610438
+      - X: -44666668
+        Y: 25419960
+      - X: -35238096
+        Y: 25419960
+    - - X: 4761905
+        Y: 25610438
+      - X: -4666667
+        Y: 25610438
+      - X: -4666667
+        Y: 25419960
+      - X: 4761905
+        Y: 25419960
+    - - X: -25238094
+        Y: 25610438
+      - X: -34666668
+        Y: 25610438
+      - X: -34666668
+        Y: 25419960
+      - X: -25238094
+        Y: 25419960
+    - - X: -238095
+        Y: 23909406
+      - X: -9666667
+        Y: 23909406
+      - X: -9666667
+        Y: 23718930
+      - X: -238095
+        Y: 23718930
+    - - X: 19761906
+        Y: 23909406
+      - X: 10333333
+        Y: 23909406
+      - X: 10333333
+        Y: 23718930
+      - X: 19761906
+        Y: 23718930
+    - - X: 34762004
+        Y: 22017857
+      - X: 34762004
+        Y: 22208417
+      - X: 34761945
+        Y: 22208476
+      - X: 25333293
+        Y: 22208476
+      - X: 25333234
+        Y: 22208417
+      - X: 25333234
+        Y: 22017857
+      - X: 25333293
+        Y: 22017798
+      - X: 34761945
+        Y: 22017798
+    - - X: -5238095
+        Y: 22208376
+      - X: -14666667
+        Y: 22208376
+      - X: -14666667
+        Y: 22017898
+      - X: -5238095
+        Y: 22017898
+    - - X: 14761906
+        Y: 22208376
+      - X: 5333333
+        Y: 22208376
+      - X: 5333333
+        Y: 22017898
+      - X: 14761906
+        Y: 22017898
+    - - X: -10238094
+        Y: 20507342
+      - X: -19666666
+        Y: 20507342
+      - X: -19666666
+        Y: 20316868
+      - X: -10238094
+        Y: 20316868
+    - - X: 29761906
+        Y: 20507342
+      - X: 20333334
+        Y: 20507342
+      - X: 20333334
+        Y: 20316868
+      - X: 29761906
+        Y: 20316868
+    - - X: 9761904
+        Y: 20507342
+      - X: 333332
+        Y: 20507342
+      - X: 333332
+        Y: 20316868
+      - X: 9761904
+        Y: 20316868
+    - - X: 14761906
+        Y: 18806312
+      - X: 5333333
+        Y: 18806312
+      - X: 5333333
+        Y: 18615836
+      - X: 14761906
+        Y: 18615836
+    - - X: 24761906
+        Y: 18806312
+      - X: 15333333
+        Y: 18806312
+      - X: 15333333
+        Y: 18615836
+      - X: 24761906
+        Y: 18615836
+    - - X: 4761905
+        Y: 18806312
+      - X: -4666667
+        Y: 18806312
+      - X: -4666667
+        Y: 18615836
+      - X: 4761905
+        Y: 18615836
+    - - X: -238095
+        Y: 17105282
+      - X: -9666667
+        Y: 17105282
+      - X: -9666667
+        Y: 16914806
+      - X: -238095
+        Y: 16914806
+    - - X: 19761906
+        Y: 17105282
+      - X: 10333333
+        Y: 17105282
+      - X: 10333333
+        Y: 16914806
+      - X: 19761906
+        Y: 16914806
+    - - X: -10238094
+        Y: 17105282
+      - X: -19666666
+        Y: 17105282
+      - X: -19666666
+        Y: 16914806
+      - X: -10238094
+        Y: 16914806
+    - - X: 9761904
+        Y: 13703220
+      - X: 333332
+        Y: 13703220
+      - X: 333332
+        Y: 13512744
+      - X: 9761904
+        Y: 13512744
+    - - X: -238095
+        Y: 13703220
+      - X: -9666667
+        Y: 13703220
+      - X: -9666667
+        Y: 13512744
+      - X: -238095
+        Y: 13512744
+    - - X: 14761906
+        Y: 12002189
+      - X: 5333333
+        Y: 12002189
+      - X: 5333333
+        Y: 11811713
+      - X: 14761906
+        Y: 11811713
+    - - X: -5238095
+        Y: 12002189
+      - X: -14666667
+        Y: 12002189
+      - X: -14666667
+        Y: 11811713
+      - X: -5238095
+        Y: 11811713
+    - - X: -10238094
+        Y: 10301158
+      - X: -19666666
+        Y: 10301158
+      - X: -19666666
+        Y: 10110682
+      - X: -10238094
+        Y: 10110682
+    - - X: 19761906
+        Y: 10301158
+      - X: 10333333
+        Y: 10301158
+      - X: 10333333
+        Y: 10110682
+      - X: 19761906
+        Y: 10110682
+    - - X: -15238094
+        Y: 8600128
+      - X: -24666666
+        Y: 8600128
+      - X: -24666666
+        Y: 8409652
+      - X: -15238094
+        Y: 8409652
+    - - X: 24761906
+        Y: 8600128
+      - X: 15333333
+        Y: 8600128
+      - X: 15333333
+        Y: 8409652
+      - X: 24761906
+        Y: 8409652
+    - - X: -20238094
+        Y: 6899097
+      - X: -29666666
+        Y: 6899097
+      - X: -29666666
+        Y: 6708621
+      - X: -20238094
+        Y: 6708621
+    - - X: 29761906
+        Y: 6899097
+      - X: 20333334
+        Y: 6899097
+      - X: 20333334
+        Y: 6708621
+      - X: 29761906
+        Y: 6708621
+    - - X: -25238094
+        Y: 5198065
+      - X: -34666668
+        Y: 5198065
+      - X: -34666668
+        Y: 5007589
+      - X: -25238094
+        Y: 5007589
+    - - X: 34761904
+        Y: 5198065
+      - X: 25333334
+        Y: 5198065
+      - X: 25333334
+        Y: 5007589
+      - X: 34761904
+        Y: 5007589
+    - - X: -30238094
+        Y: 3497035
+      - X: -39666668
+        Y: 3497035
+      - X: -39666668
+        Y: 3306558
+      - X: -30238094
+        Y: 3306558
+    - - X: 39761904
+        Y: 3497035
+      - X: 30333334
+        Y: 3497035
+      - X: 30333334
+        Y: 3306558
+      - X: 39761904
+        Y: 3306558
+    - - X: 44761904
+        Y: 1796004
+      - X: 35333332
+        Y: 1796004
+      - X: 35333332
+        Y: 1605528
+      - X: 44761904
+        Y: 1605528
+    - - X: -35238096
+        Y: 1796004
+      - X: -44666668
+        Y: 1796004
+      - X: -44666668
+        Y: 1605528
+      - X: -35238096
+        Y: 1605528
+    - - X: -35237996
+        Y: -1796574
+      - X: -35237996
+        Y: -1606016
+      - X: -35238055
+        Y: -1605957
+      - X: -44666709
+        Y: -1605957
+      - X: -44666768
+        Y: -1606016
+      - X: -44666768
+        Y: -1796574
+      - X: -44666709
+        Y: -1796633
+      - X: -35238055
+        Y: -1796633
+    - - X: 44761904
+        Y: -1606057
+      - X: 35333332
+        Y: -1606057
+      - X: 35333332
+        Y: -1796533
+      - X: 44761904
+        Y: -1796533
+    - - X: -30238094
+        Y: -3307088
+      - X: -39666668
+        Y: -3307088
+      - X: -39666668
+        Y: -3497564
+      - X: -30238094
+        Y: -3497564
+    - - X: 39761904
+        Y: -3307088
+      - X: 30333334
+        Y: -3307088
+      - X: 30333334
+        Y: -3497564
+      - X: 39761904
+        Y: -3497564
+    - - X: -25238094
+        Y: -5008119
+      - X: -34666668
+        Y: -5008119
+      - X: -34666668
+        Y: -5198595
+      - X: -25238094
+        Y: -5198595
+    - - X: 34761904
+        Y: -5008119
+      - X: 25333334
+        Y: -5008119
+      - X: 25333334
+        Y: -5198595
+      - X: 34761904
+        Y: -5198595
+    - - X: 29761906
+        Y: -6709150
+      - X: 20333334
+        Y: -6709150
+      - X: 20333334
+        Y: -6899626
+      - X: 29761906
+        Y: -6899626
+    - - X: -20238094
+        Y: -6709150
+      - X: -29666666
+        Y: -6709150
+      - X: -29666666
+        Y: -6899626
+      - X: -20238094
+        Y: -6899626
+    - - X: 24761906
+        Y: -8410182
+      - X: 15333333
+        Y: -8410182
+      - X: 15333333
+        Y: -8600658
+      - X: 24761906
+        Y: -8600658
+    - - X: -15238094
+        Y: -8410182
+      - X: -24666666
+        Y: -8410182
+      - X: -24666666
+        Y: -8600658
+      - X: -15238094
+        Y: -8600658
+    - - X: -10238094
+        Y: -10111213
+      - X: -19666666
+        Y: -10111213
+      - X: -19666666
+        Y: -10301689
+      - X: -10238094
+        Y: -10301689
+    - - X: 19761906
+        Y: -10111213
+      - X: 10333333
+        Y: -10111213
+      - X: 10333333
+        Y: -10301689
+      - X: 19761906
+        Y: -10301689
+    - - X: -5238095
+        Y: -11812243
+      - X: -14666667
+        Y: -11812243
+      - X: -14666667
+        Y: -12002720
+      - X: -5238095
+        Y: -12002720
+    - - X: 14761906
+        Y: -11812243
+      - X: 5333333
+        Y: -11812243
+      - X: 5333333
+        Y: -12002720
+      - X: 14761906
+        Y: -12002720
+    - - X: -238095
+        Y: -13513274
+      - X: -9666667
+        Y: -13513274
+      - X: -9666667
+        Y: -13703750
+      - X: -238095
+        Y: -13703750
+    - - X: 9761904
+        Y: -13513274
+      - X: 333332
+        Y: -13513274
+      - X: 333332
+        Y: -13703750
+      - X: 9761904
+        Y: -13703750
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.9761611, y: 4.0729237}
+      - {x: 0.9761611, y: 4.0919714}
+      - {x: 0.0333332, y: 4.091942}
+      - {x: 0.0333625, y: 4.0729237}
+    - - {x: -0.0238388, y: 4.0729237}
+      - {x: -0.0238388, y: 4.0919714}
+      - {x: -0.9666667, y: 4.091942}
+      - {x: -0.96663743, y: 4.0729237}
+    - - {x: -0.5238388, y: 3.9028203}
+      - {x: -0.5238388, y: 3.9218686}
+      - {x: -1.4666667, y: 3.9218392}
+      - {x: -1.4666374, y: 3.9028203}
+    - - {x: 0.97616524, y: 3.7327077}
+      - {x: 0.97616524, y: 3.7517753}
+      - {x: 0.0333232, y: 3.75174}
+      - {x: 0.0333584, y: 3.7327077}
+    - - {x: -1.0238388, y: 3.7327178}
+      - {x: -1.0238388, y: 3.7517653}
+      - {x: -1.9666666, y: 3.751736}
+      - {x: -1.9666373, y: 3.7327178}
+    - - {x: 0.4761612, y: 3.5626144}
+      - {x: 0.4761612, y: 3.581662}
+      - {x: -0.4666667, y: 3.5816329}
+      - {x: -0.4666374, y: 3.5626144}
+    - - {x: -1.5238388, y: 3.5626144}
+      - {x: -1.5238388, y: 3.581662}
+      - {x: -2.4666667, y: 3.5816329}
+      - {x: -2.4666371, y: 3.5626144}
+    - - {x: 1.9761654, y: 3.3925014}
+      - {x: 1.9761654, y: 3.4115694}
+      - {x: 1.0333233, y: 3.411534}
+      - {x: 1.0333585, y: 3.3925014}
+    - - {x: 2.9761612, y: 3.3925111}
+      - {x: 2.9761612, y: 3.4115593}
+      - {x: 2.0333335, y: 3.41153}
+      - {x: 2.0333629, y: 3.3925111}
+    - - {x: -0.0238388, y: 3.3925111}
+      - {x: -0.0238388, y: 3.4115593}
+      - {x: -0.9666667, y: 3.41153}
+      - {x: -0.96663743, y: 3.3925111}
+    - - {x: -2.0238388, y: 3.3925111}
+      - {x: -2.0238388, y: 3.4115593}
+      - {x: -2.9666667, y: 3.41153}
+      - {x: -2.9666371, y: 3.3925111}
+    - - {x: 0.4761653, y: 3.2223983}
+      - {x: 0.4761653, y: 3.241466}
+      - {x: -0.4666767, y: 3.2414308}
+      - {x: -0.46664152, y: 3.2223983}
+    - - {x: 3.4761612, y: 3.2224083}
+      - {x: 3.4761612, y: 3.241456}
+      - {x: 2.5333335, y: 3.241427}
+      - {x: 2.5333629, y: 3.2224083}
+    - - {x: -2.5238388, y: 3.2224083}
+      - {x: -2.5238388, y: 3.241456}
+      - {x: -3.466667, y: 3.241427}
+      - {x: -3.4666376, y: 3.2224083}
+    - - {x: 3.9761612, y: 3.0523052}
+      - {x: 3.9761612, y: 3.071353}
+      - {x: 3.0333335, y: 3.0713236}
+      - {x: 3.0333629, y: 3.0523052}
+    - - {x: 1.9761612, y: 3.0523052}
+      - {x: 1.9761612, y: 3.071353}
+      - {x: 1.0333333, y: 3.0713236}
+      - {x: 1.0333626, y: 3.0523052}
+    - - {x: 0.9761611, y: 3.0523052}
+      - {x: 0.9761611, y: 3.071353}
+      - {x: 0.0333332, y: 3.0713236}
+      - {x: 0.0333625, y: 3.0523052}
+    - - {x: -1.0238388, y: 3.0523052}
+      - {x: -1.0238388, y: 3.071353}
+      - {x: -1.9666666, y: 3.0713236}
+      - {x: -1.9666373, y: 3.0523052}
+    - - {x: -3.0238388, y: 3.0523052}
+      - {x: -3.0238388, y: 3.071353}
+      - {x: -3.966667, y: 3.0713236}
+      - {x: -3.9666376, y: 3.0523052}
+    - - {x: -0.5238347, y: 2.8821921}
+      - {x: -0.5238347, y: 2.90126}
+      - {x: -1.4666767, y: 2.9012246}
+      - {x: -1.4666415, y: 2.8821921}
+    - - {x: 1.4761614, y: 2.8822021}
+      - {x: 1.4761614, y: 2.90125}
+      - {x: 0.5333333, y: 2.9012203}
+      - {x: 0.5333626, y: 2.8822021}
+    - - {x: -1.5238388, y: 2.8822021}
+      - {x: -1.5238388, y: 2.90125}
+      - {x: -2.4666667, y: 2.9012203}
+      - {x: -2.4666371, y: 2.8822021}
+    - - {x: -3.5238388, y: 2.8822021}
+      - {x: -3.5238388, y: 2.90125}
+      - {x: -4.4666667, y: 2.9012203}
+      - {x: -4.4666376, y: 2.8822021}
+    - - {x: 3.9761612, y: 2.712099}
+      - {x: 3.9761612, y: 2.7311468}
+      - {x: 3.0333335, y: 2.7311177}
+      - {x: 3.0333629, y: 2.712099}
+    - - {x: 2.9761612, y: 2.712099}
+      - {x: 2.9761612, y: 2.7311468}
+      - {x: 2.0333335, y: 2.7311177}
+      - {x: 2.0333629, y: 2.712099}
+    - - {x: -0.0238388, y: 2.712099}
+      - {x: -0.0238388, y: 2.7311468}
+      - {x: -0.9666667, y: 2.7311177}
+      - {x: -0.96663743, y: 2.712099}
+    - - {x: -2.0238388, y: 2.712099}
+      - {x: -2.0238388, y: 2.7311468}
+      - {x: -2.9666667, y: 2.7311177}
+      - {x: -2.9666371, y: 2.712099}
+    - - {x: 3.4761653, y: 2.541986}
+      - {x: 3.4761653, y: 2.5610538}
+      - {x: 2.5333235, y: 2.5610187}
+      - {x: 2.5333586, y: 2.541986}
+    - - {x: 0.4761612, y: 2.541996}
+      - {x: 0.4761612, y: 2.5610437}
+      - {x: -0.4666667, y: 2.5610144}
+      - {x: -0.4666374, y: 2.541996}
+    - - {x: -2.5238388, y: 2.541996}
+      - {x: -2.5238388, y: 2.5610437}
+      - {x: -3.466667, y: 2.5610144}
+      - {x: -3.4666376, y: 2.541996}
+    - - {x: -3.5238388, y: 2.541996}
+      - {x: -3.5238388, y: 2.5610437}
+      - {x: -4.4666667, y: 2.5610144}
+      - {x: -4.4666376, y: 2.541996}
+    - - {x: 1.9761612, y: 2.371893}
+      - {x: 1.9761612, y: 2.3909407}
+      - {x: 1.0333333, y: 2.3909113}
+      - {x: 1.0333626, y: 2.371893}
+    - - {x: -0.0238388, y: 2.371893}
+      - {x: -0.0238388, y: 2.3909407}
+      - {x: -0.9666667, y: 2.3909113}
+      - {x: -0.96663743, y: 2.371893}
+    - - {x: 3.4761653, y: 2.2017798}
+      - {x: 3.4761653, y: 2.2208476}
+      - {x: 2.5333235, y: 2.2208123}
+      - {x: 2.5333586, y: 2.2017798}
+    - - {x: 1.4761614, y: 2.2017899}
+      - {x: 1.4761614, y: 2.2208376}
+      - {x: 0.5333333, y: 2.2208085}
+      - {x: 0.5333626, y: 2.2017899}
+    - - {x: -0.5238388, y: 2.2017899}
+      - {x: -0.5238388, y: 2.2208376}
+      - {x: -1.4666667, y: 2.2208085}
+      - {x: -1.4666374, y: 2.2017899}
+    - - {x: 2.9761612, y: 2.0316868}
+      - {x: 2.9761612, y: 2.0507343}
+      - {x: 2.0333335, y: 2.0507047}
+      - {x: 2.0333629, y: 2.0316868}
+    - - {x: 0.9761611, y: 2.0316868}
+      - {x: 0.9761611, y: 2.0507343}
+      - {x: 0.0333332, y: 2.0507047}
+      - {x: 0.0333625, y: 2.0316868}
+    - - {x: -1.0238388, y: 2.0316868}
+      - {x: -1.0238388, y: 2.0507343}
+      - {x: -1.9666666, y: 2.0507047}
+      - {x: -1.9666373, y: 2.0316868}
+    - - {x: 2.4761612, y: 1.8615836}
+      - {x: 2.4761612, y: 1.8806312}
+      - {x: 1.5333333, y: 1.880602}
+      - {x: 1.5333626, y: 1.8615836}
+    - - {x: 1.4761614, y: 1.8615836}
+      - {x: 1.4761614, y: 1.8806312}
+      - {x: 0.5333333, y: 1.880602}
+      - {x: 0.5333626, y: 1.8615836}
+    - - {x: 0.4761612, y: 1.8615836}
+      - {x: 0.4761612, y: 1.8806312}
+      - {x: -0.4666667, y: 1.880602}
+      - {x: -0.4666374, y: 1.8615836}
+    - - {x: 1.9761612, y: 1.6914806}
+      - {x: 1.9761612, y: 1.7105283}
+      - {x: 1.0333333, y: 1.7104988}
+      - {x: 1.0333626, y: 1.6914806}
+    - - {x: -0.0238388, y: 1.6914806}
+      - {x: -0.0238388, y: 1.7105283}
+      - {x: -0.9666667, y: 1.7104988}
+      - {x: -0.96663743, y: 1.6914806}
+    - - {x: -1.0238388, y: 1.6914806}
+      - {x: -1.0238388, y: 1.7105283}
+      - {x: -1.9666666, y: 1.7104988}
+      - {x: -1.9666373, y: 1.6914806}
+    - - {x: 0.9761611, y: 1.3512744}
+      - {x: 0.9761611, y: 1.370322}
+      - {x: 0.0333332, y: 1.3702927}
+      - {x: 0.0333625, y: 1.3512744}
+    - - {x: -0.0238388, y: 1.3512744}
+      - {x: -0.0238388, y: 1.370322}
+      - {x: -0.9666667, y: 1.3702927}
+      - {x: -0.96663743, y: 1.3512744}
+    - - {x: 1.4761614, y: 1.1811713}
+      - {x: 1.4761614, y: 1.2002189}
+      - {x: 0.5333333, y: 1.2001896}
+      - {x: 0.5333626, y: 1.1811713}
+    - - {x: -0.5238388, y: 1.1811713}
+      - {x: -0.5238388, y: 1.2002189}
+      - {x: -1.4666667, y: 1.2001896}
+      - {x: -1.4666374, y: 1.1811713}
+    - - {x: 1.9761612, y: 1.0110682}
+      - {x: 1.9761612, y: 1.0301158}
+      - {x: 1.0333333, y: 1.0300865}
+      - {x: 1.0333626, y: 1.0110682}
+    - - {x: -1.0238388, y: 1.0110682}
+      - {x: -1.0238388, y: 1.0301158}
+      - {x: -1.9666666, y: 1.0300865}
+      - {x: -1.9666373, y: 1.0110682}
+    - - {x: 2.4761612, y: 0.8409652}
+      - {x: 2.4761612, y: 0.8600128}
+      - {x: 1.5333333, y: 0.8599835}
+      - {x: 1.5333626, y: 0.8409652}
+    - - {x: -1.5238388, y: 0.8409652}
+      - {x: -1.5238388, y: 0.8600128}
+      - {x: -2.4666667, y: 0.8599835}
+      - {x: -2.4666371, y: 0.8409652}
+    - - {x: 2.9761612, y: 0.6708621}
+      - {x: 2.9761612, y: 0.6899097}
+      - {x: 2.0333335, y: 0.68988043}
+      - {x: 2.0333629, y: 0.6708621}
+    - - {x: -2.0238388, y: 0.6708621}
+      - {x: -2.0238388, y: 0.6899097}
+      - {x: -2.9666667, y: 0.68988043}
+      - {x: -2.9666371, y: 0.6708621}
+    - - {x: 3.4761612, y: 0.5007589}
+      - {x: 3.4761612, y: 0.5198065}
+      - {x: 2.5333335, y: 0.5197772}
+      - {x: 2.5333629, y: 0.5007589}
+    - - {x: -2.5238388, y: 0.5007589}
+      - {x: -2.5238388, y: 0.5198065}
+      - {x: -3.466667, y: 0.5197772}
+      - {x: -3.4666376, y: 0.5007589}
+    - - {x: 3.9761612, y: 0.3306558}
+      - {x: 3.9761612, y: 0.3497035}
+      - {x: 3.0333335, y: 0.3496742}
+      - {x: 3.0333629, y: 0.3306558}
+    - - {x: -3.0238388, y: 0.3306558}
+      - {x: -3.0238388, y: 0.3497035}
+      - {x: -3.966667, y: 0.3496742}
+      - {x: -3.9666376, y: 0.3306558}
+    - - {x: 4.4761615, y: 0.1605528}
+      - {x: 4.4761615, y: 0.1796004}
+      - {x: 3.5333333, y: 0.1795711}
+      - {x: 3.5333624, y: 0.1605528}
+    - - {x: -3.5238388, y: 0.1605528}
+      - {x: -3.5238388, y: 0.1796004}
+      - {x: -4.4666667, y: 0.1795711}
+      - {x: -4.4666376, y: 0.1605528}
+    - - {x: -3.523835, y: -0.1796633}
+      - {x: -3.523835, y: -0.1605957}
+      - {x: -4.4666767, y: -0.1606309}
+      - {x: -4.4666414, y: -0.1796633}
+    - - {x: 4.4761615, y: -0.1796533}
+      - {x: 4.4761615, y: -0.1606057}
+      - {x: 3.5333333, y: -0.160635}
+      - {x: 3.5333624, y: -0.1796533}
+    - - {x: 3.9761612, y: -0.3497564}
+      - {x: 3.9761612, y: -0.3307088}
+      - {x: 3.0333335, y: -0.3307381}
+      - {x: 3.0333629, y: -0.3497564}
+    - - {x: -3.0238388, y: -0.3497564}
+      - {x: -3.0238388, y: -0.3307088}
+      - {x: -3.966667, y: -0.3307381}
+      - {x: -3.9666376, y: -0.3497564}
+    - - {x: 3.4761612, y: -0.5198595}
+      - {x: 3.4761612, y: -0.50081193}
+      - {x: 2.5333335, y: -0.5008412}
+      - {x: 2.5333629, y: -0.5198595}
+    - - {x: -2.5238388, y: -0.5198595}
+      - {x: -2.5238388, y: -0.50081193}
+      - {x: -3.466667, y: -0.5008412}
+      - {x: -3.4666376, y: -0.5198595}
+    - - {x: 2.9761612, y: -0.6899626}
+      - {x: 2.9761612, y: -0.670915}
+      - {x: 2.0333335, y: -0.67094433}
+      - {x: 2.0333629, y: -0.6899626}
+    - - {x: -2.0238388, y: -0.6899626}
+      - {x: -2.0238388, y: -0.670915}
+      - {x: -2.9666667, y: -0.67094433}
+      - {x: -2.9666371, y: -0.6899626}
+    - - {x: 2.4761612, y: -0.8600658}
+      - {x: 2.4761612, y: -0.8410182}
+      - {x: 1.5333333, y: -0.8410475}
+      - {x: 1.5333626, y: -0.8600658}
+    - - {x: -1.5238388, y: -0.8600658}
+      - {x: -1.5238388, y: -0.8410182}
+      - {x: -2.4666667, y: -0.8410475}
+      - {x: -2.4666371, y: -0.8600658}
+    - - {x: 1.9761612, y: -1.0301689}
+      - {x: 1.9761612, y: -1.0111213}
+      - {x: 1.0333333, y: -1.0111506}
+      - {x: 1.0333626, y: -1.0301689}
+    - - {x: -1.0238388, y: -1.0301689}
+      - {x: -1.0238388, y: -1.0111213}
+      - {x: -1.9666666, y: -1.0111506}
+      - {x: -1.9666373, y: -1.0301689}
+    - - {x: 1.4761614, y: -1.200272}
+      - {x: 1.4761614, y: -1.1812243}
+      - {x: 0.5333333, y: -1.1812537}
+      - {x: 0.5333626, y: -1.200272}
+    - - {x: -0.5238388, y: -1.200272}
+      - {x: -0.5238388, y: -1.1812243}
+      - {x: -1.4666667, y: -1.1812537}
+      - {x: -1.4666374, y: -1.200272}
+    - - {x: 0.9761611, y: -1.370375}
+      - {x: 0.9761611, y: -1.3513274}
+      - {x: 0.0333332, y: -1.3513567}
+      - {x: 0.0333625, y: -1.370375}
+    - - {x: -0.0238388, y: -1.370375}
+      - {x: -0.0238388, y: -1.3513274}
+      - {x: -0.9666667, y: -1.3513567}
+      - {x: -0.96663743, y: -1.370375}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005
+--- !u!50 &1762346267
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!19719996 &1762346268
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
+  m_MaximumTileChangeCount: 1000
+  m_ExtrusionFactor: 0.00001
+--- !u!483693784 &1762346269
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1600035685
+  m_SortingLayer: 5
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0.014259219, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 3
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &1762346270
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762346264}
+  m_Enabled: 1
+  m_Tiles:
+  - first: {x: -4, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -3, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: -4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: -3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: -2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: -1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: 1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -5, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -4, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -3, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: 6, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 6, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 8, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 9, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 10, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 12, y: 11, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 5, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 7, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 8, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 9, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 10, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 11, y: 12, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  m_AnimatedTiles: {}
+  m_TileAssetArray:
+  - m_RefCount: 77
+    m_Data: {fileID: 11400000, guid: d9ad08308d8d82c4f8a077bfd6ec68b4, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 77
+    m_Data: {fileID: 21300000, guid: bb23e60d78c4aa8438ac209fdfbb034e, type: 3}
+  m_TileMatrixArray:
+  - m_RefCount: 77
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 77
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Origin: {x: -5, y: -5, z: 0}
+  m_Size: {x: 18, y: 18, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!1 &1807078270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807078271}
+  m_Layer: 0
+  m_Name: -------UI---------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1807078271
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807078270}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.98128676, y: 0.06902208, z: -0.023578368}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1808384721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1808384722}
+  m_Layer: 0
+  m_Name: ---------Other MapObjects-----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1808384722
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808384721}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.5744351, y: 2.5870008, z: -0.0515978}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!68 &1810778166 stripped
+EdgeCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 150655228}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1821296678 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 861931078}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1824976653 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1547749426}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1864480714
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.6056128
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7060239986491409134, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+        type: 3}
+      propertyPath: m_Name
+      value: HeightDetector_red
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fcdfbb301b719b948a71ba79bc4e9cfe, type: 3}
+--- !u!1 &1870174347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1870174348}
+  m_Layer: 0
+  m_Name: ----------Yellow Platform----------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1870174348
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870174347}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.5744351, y: 2.5870008, z: -0.0515978}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084451319}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2018295209
 GameObject:
   m_ObjectHideFlags: 0
@@ -6425,6 +8090,299 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2041664247
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2041664250}
+  - component: {fileID: 2041664249}
+  - component: {fileID: 2041664248}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2041664248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041664247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+--- !u!114 &2041664249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041664247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &2041664250
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041664247}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2063741017 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1068218978245808900, guid: dd098490cc6c7d04492ac7c08e506340,
+    type: 3}
+  m_PrefabInstance: {fileID: 835477586}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2063741023 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1068218978245809019, guid: dd098490cc6c7d04492ac7c08e506340,
+    type: 3}
+  m_PrefabInstance: {fileID: 835477586}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063741017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af094f3f6be984d9d9c6cd214c515c95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2063741028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1068218978245808901, guid: dd098490cc6c7d04492ac7c08e506340,
+    type: 3}
+  m_PrefabInstance: {fileID: 835477586}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2063741029 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8807749665105663781, guid: dd098490cc6c7d04492ac7c08e506340,
+    type: 3}
+  m_PrefabInstance: {fileID: 835477586}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063741017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b64ac922449503740a905da9fc71e443, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2063741030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063741017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb406fdbecaaa4831b72ebcdc806a9e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UDCollider: {fileID: 2063741031}
+  LRCollider: {fileID: 2063741032}
+--- !u!68 &2063741031
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063741017}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.2616284, y: -0.07397726}
+  - {x: 0.18765116, y: 0.09041679}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!68 &2063741032
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063741017}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.24107909, y: 0.09452665}
+  - {x: 0.22053003, y: -0.069867566}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
+--- !u!1001 &2066823331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1715205590}
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[1]
+      value: 
+      objectReference: {fileID: 1821296678}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.75686276
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825429957497, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025937, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Name
+      value: ActivatePlatform_yellow_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.528
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c42903ead897beb4f9f98b1568c3cb53, type: 3}
+--- !u!4 &2069284871 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409133, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 1864480714}
+  m_PrefabAsset: {fileID: 0}
+--- !u!68 &2069284872 stripped
+EdgeCollider2D:
+  m_CorrespondingSourceObject: {fileID: 7060239986491409132, guid: fcdfbb301b719b948a71ba79bc4e9cfe,
+    type: 3}
+  m_PrefabInstance: {fileID: 1864480714}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2084451317
 GameObject:
   m_ObjectHideFlags: 0
@@ -6467,28 +8425,469 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1759387012}
-  - {fileID: 1425439406}
-  - {fileID: 1678283528}
-  - {fileID: 109615037}
-  - {fileID: 1835482283}
-  - {fileID: 618546459}
-  - {fileID: 444203780}
-  - {fileID: 776975818}
-  - {fileID: 1801806159}
-  - {fileID: 751570947}
-  - {fileID: 1751928565}
-  - {fileID: 798842462}
-  - {fileID: 553443920}
-  - {fileID: 307939293}
-  - {fileID: 141163498}
-  - {fileID: 1268293324}
-  - {fileID: 1766550508}
-  - {fileID: 1502114861}
-  - {fileID: 1451406880}
-  - {fileID: 1849268498}
-  - {fileID: 1326444435}
-  - {fileID: 785212918}
-  - {fileID: 1707362409}
+  - {fileID: 1568558545}
+  - {fileID: 490090050}
+  - {fileID: 1762346265}
+  - {fileID: 604132975}
+  - {fileID: 731533930}
+  - {fileID: 2063741028}
+  - {fileID: 1097655421}
+  - {fileID: 1241649408}
+  - {fileID: 185496246}
+  - {fileID: 1520996010}
+  - {fileID: 193730201}
+  - {fileID: 122469080}
+  - {fileID: 1870174348}
+  - {fileID: 1063425493}
+  - {fileID: 821922301}
+  - {fileID: 2095137374}
+  - {fileID: 1382893553}
+  - {fileID: 836803926}
+  - {fileID: 150655229}
+  - {fileID: 218104319}
+  - {fileID: 1171668764}
+  - {fileID: 855447665}
+  - {fileID: 2069284871}
+  - {fileID: 896176741}
+  - {fileID: 1808384722}
+  - {fileID: 527188123}
+  - {fileID: 6081139255931825897}
+  - {fileID: 1503894989}
+  - {fileID: 1389574068}
+  - {fileID: 1161721684}
+  - {fileID: 477395426}
+  - {fileID: 133003789}
+  - {fileID: 126846549}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2095137374 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2119476458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2107578598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2107578599}
+  m_Layer: 0
+  m_Name: Raised
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2107578599
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2107578598}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1503894989}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2119476458
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.75686276
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177528, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256600177529, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 6081139256600177531, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: heightDetector
+      value: 
+      objectReference: {fileID: 1382893554}
+    - target: {fileID: 6081139256700975352, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_Name
+      value: MovePlatform_yellow_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.299
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081139256700975355, guid: 8164be588fb25d549b8dfcfc4609f1b1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8164be588fb25d549b8dfcfc4609f1b1, type: 3}
+--- !u!1001 &3700762156170515984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[0].x
+      value: 0.16279222
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[0].y
+      value: 0.101218745
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[1].x
+      value: -0.016661964
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[1].y
+      value: 0.17514683
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[2].x
+      value: -0.16454586
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[2].y
+      value: 0.095948346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[3].x
+      value: -0.0029462427
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644020, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Points.m_Paths.Array.data[0].Array.data[3].y
+      value: 0.037072353
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824231644025, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: heightDetector
+      value: 
+      objectReference: {fileID: 1238002324}
+    - target: {fileID: 7439722824231644027, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: tilemap
+      value: 
+      objectReference: {fileID: 1568558543}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.786
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7439722824400337146, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+        type: 3}
+      propertyPath: m_Name
+      value: MovePlatform_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 7439722824231644025, guid: 7a7b81f4a4a96084d8c9c735a28c2326, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 7a7b81f4a4a96084d8c9c735a28c2326, type: 3}
+--- !u!1001 &4958872824416002808
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObject
+      value: 
+      objectReference: {fileID: 1755834168}
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8734480737060793781, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1755834168}
+    - target: {fileID: 4958872825916025937, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Name
+      value: ActivatePlatform_green_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025937, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.033
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.829
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958872825916025938, guid: c42903ead897beb4f9f98b1568c3cb53,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c42903ead897beb4f9f98b1568c3cb53, type: 3}
+--- !u!1001 &5179123074537910888
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2084451319}
+    m_Modifications:
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObject
+      value: 
+      objectReference: {fileID: 1755834168}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221392, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: movePlatformObjectList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1755834168}
+    - target: {fileID: 5179123074688221405, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_Name
+      value: ActivatePlatform_green_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.967
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.479
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5179123074688221406, guid: 804d7324a43877945bf5d11cd2f0b5e9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 804d7324a43877945bf5d11cd2f0b5e9, type: 3}
+--- !u!4 &6081139255931825897 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7439722824400337145, guid: 7a7b81f4a4a96084d8c9c735a28c2326,
+    type: 3}
+  m_PrefabInstance: {fileID: 3700762156170515984}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/secminhr_test_scene.unity.meta
+++ b/Assets/Scenes/secminhr_test_scene.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 90b19908a2fa84b91a4f37b43f4c5f95
+guid: 6281a55ecc19a4acd89f0658ebd8c372
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scripts/Character/CharacterCollider.cs
+++ b/Assets/Scripts/Character/CharacterCollider.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using static UnityEngine.Mathf;
+
+[ExecuteAlways]
+public class CharacterCollider : MonoBehaviour
+{
+    public CustomCollider2D customCollider;
+    public Grid grid;
+    public float scale = 0.3f;
+
+    private List<Vector2> LRCollider;
+    private List<Vector2> UDCollider;
+
+    void Start()
+    {
+        if (!Application.IsPlaying(gameObject)) return;
+        createColliders();
+        useColliders(LRCollider, UDCollider);
+    }
+
+    void Update()
+    {
+        if (Application.IsPlaying(gameObject)) return;
+        createColliders();
+        useColliders(LRCollider, UDCollider);
+    }
+
+    private void createColliders()
+    {
+        float x = grid.cellSize.x * scale;
+        float y = grid.cellSize.y * scale;
+
+        LRCollider = createPolygon(x, y);
+        UDCollider = createPolygon(-x, y); //flipped on x axis
+    }
+
+    private List<Vector2> createPolygon(float x, float y)
+    {
+        Vector2 offset = new Vector2(x / 2, y / 2);
+        float dy = 0.001f;
+        return new List<Vector2>
+        {
+            new Vector2(x, 0) - offset,
+            new Vector2(0, y) - offset,
+            new Vector2(x*dy/y, y+dy) - offset,
+            new Vector2(x+x*dy/y, dy) - offset
+        };
+    }
+
+    public void UseLRCollider()
+    {
+        useColliders(LRCollider);
+    }
+
+    public void UseUDCollider()
+    {
+        useColliders(UDCollider);
+    }
+
+    public void UseAllColliders()
+    {
+        useColliders(LRCollider, UDCollider);
+    }
+
+    private void useColliders(params List<Vector2>[] colliders)
+    {
+        PhysicsShapeGroup2D shapeGroup = new PhysicsShapeGroup2D();
+        foreach (List<Vector2> vertices in colliders)
+        {
+            shapeGroup.AddPolygon(vertices);
+        }
+        customCollider.SetCustomShapes(shapeGroup);
+    }
+}

--- a/Assets/Scripts/Character/CharacterCollider.cs.meta
+++ b/Assets/Scripts/Character/CharacterCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8584a455d02cc47b6acb7d2227a82e5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Character/CharacterColliderSelector.cs
+++ b/Assets/Scripts/Character/CharacterColliderSelector.cs
@@ -8,25 +8,24 @@ using static GridMovement;
 public class CharacterColliderSelector : MonoBehaviour
 {
     [SerializeField]
-    [Header("The collider that expands in up-down direction")]
-    private Collider2D UDCollider;
-    [SerializeField]
-    [Header("The collider that expands in left-right direction")]
-    private Collider2D LRCollider;
+    private CharacterCollider characterCollider;
+
     void Start()
     {
         GridMovement movement = GetComponent<GridMovement>();
         movement.BeforeMoveEvent += (Action _, ref Vector2 _) =>
         {
             //enable the collider which is perpendicular to moving direction
-            UDCollider.enabled = !movingUpOrDown(movement);
-            LRCollider.enabled = movingUpOrDown(movement);
+            if (movingUpOrDown(movement))
+            {
+                characterCollider.UseLRCollider();
+            }
+            else
+            {
+                characterCollider.UseUDCollider();
+            }
         };
-        movement.MoveFinishedEvent += () =>
-        {
-            UDCollider.enabled = true;
-            LRCollider.enabled = true;
-        };
+        movement.MoveFinishedEvent += characterCollider.UseAllColliders;
     }
 
     private bool movingUpOrDown(GridMovement movement)

--- a/Assets/Scripts/Character/CharacterColliderSelector.cs
+++ b/Assets/Scripts/Character/CharacterColliderSelector.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using static GridMovement;
+
+[RequireComponent(typeof(GridMovement))]
+public class CharacterColliderSelector : MonoBehaviour
+{
+    [SerializeField]
+    [Header("The collider that expands in up-down direction")]
+    private Collider2D UDCollider;
+    [SerializeField]
+    [Header("The collider that expands in left-right direction")]
+    private Collider2D LRCollider;
+    void Start()
+    {
+        GridMovement movement = GetComponent<GridMovement>();
+        movement.BeforeMoveEvent += (Action _, ref Vector2 _) =>
+        {
+            //enable the collider which is perpendicular to moving direction
+            UDCollider.enabled = !movingUpOrDown(movement);
+            LRCollider.enabled = movingUpOrDown(movement);
+        };
+        movement.MoveFinishedEvent += () =>
+        {
+            UDCollider.enabled = true;
+            LRCollider.enabled = true;
+        };
+    }
+
+    private bool movingUpOrDown(GridMovement movement)
+    {
+        return movement.Facing == Direction.UP || movement.Facing == Direction.DOWN;
+    }
+}

--- a/Assets/Scripts/Character/CharacterColliderSelector.cs.meta
+++ b/Assets/Scripts/Character/CharacterColliderSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb406fdbecaaa4831b72ebcdc806a9e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. Character collider is adjusted to a cross.
2. When the character is moving, only the collider which is perpendicular to the moving direction will be enabled.

## Scene Change
1. Character collider
2. New component on Character: `CharacterColliderSelector` with proper setup (colliders must be specified)

A series of PRs will follow to propose a way of specifying the collision order of exiting a tile and entering its neighbor.