### PR TITLE
Obtain x and y unit directly from Grid

### DIFF
--- a/Assets/Scenes/secminhr_test_scene.unity
+++ b/Assets/Scenes/secminhr_test_scene.unity
@@ -306,6 +306,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Character_2P
       objectReference: {fileID: 0}
+    - target: {fileID: 2470534266370304792, guid: f8af041d9e5c91b40acde3af53899501,
+        type: 3}
+      propertyPath: grid
+      value: 
+      objectReference: {fileID: 2084451318}
     - target: {fileID: 2470534266370304794, guid: f8af041d9e5c91b40acde3af53899501,
         type: 3}
       propertyPath: otherInteractor
@@ -438,7 +443,7 @@ PrefabInstance:
     - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
         type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 505959569468933103, guid: d84b2efade7bd2646b2158686033e972,
         type: 3}
@@ -3346,6 +3351,11 @@ PrefabInstance:
       propertyPath: otherInteractor
       value: 
       objectReference: {fileID: 1097655427}
+    - target: {fileID: 1068218978245809021, guid: dd098490cc6c7d04492ac7c08e506340,
+        type: 3}
+      propertyPath: grid
+      value: 
+      objectReference: {fileID: 2084451318}
     - target: {fileID: 1068218979012799797, guid: dd098490cc6c7d04492ac7c08e506340,
         type: 3}
       propertyPath: m_Enabled

--- a/Assets/Scripts/Character/GridMovement.cs
+++ b/Assets/Scripts/Character/GridMovement.cs
@@ -8,8 +8,10 @@ using UnityEngine.Tilemaps;
 /// </summary>
 public class GridMovement : MonoBehaviour
 {
-    public float xUnit = 1f;
-    public float yUnit = 0.37f;
+    public Grid grid;
+
+    public float xUnit => grid.cellSize.x;
+    public float yUnit => grid.cellSize.y;
 
     public float stepDuration = 0.5f;
     private float stepStopAccumulated = 0f;


### PR DESCRIPTION
Directly get x and y unit (for moving) from Grid to achieve accurate movement positioning.

## Scene change
1. `GridMovement` now uses a `Grid` in its configuration instead of `x unit` and `y unit`