### PR TITLE
Change behavior of GridMovement.MoveFinishedEvent

### DIFF
--- a/Assets/Scripts/Character/CharacterColliderSelector.cs
+++ b/Assets/Scripts/Character/CharacterColliderSelector.cs
@@ -25,7 +25,7 @@ public class CharacterColliderSelector : MonoBehaviour
                 characterCollider.UseUDCollider();
             }
         };
-        movement.MoveFinishedEvent += characterCollider.UseAllColliders;
+        movement.MoveFinishedEvent += (_) => characterCollider.UseAllColliders();
     }
 
     private bool movingUpOrDown(GridMovement movement)

--- a/Assets/Scripts/Character/GridMovement.cs
+++ b/Assets/Scripts/Character/GridMovement.cs
@@ -43,7 +43,7 @@ public class GridMovement : MonoBehaviour
     /// </summary>
     public event BeforeMove BeforeMoveEvent;
 
-    public delegate void MoveFinished();
+    public delegate void MoveFinished(bool positionChanged);
     /// <summary>
     /// The event that will invoke after moving to the destination
     /// </summary>
@@ -58,7 +58,7 @@ public class GridMovement : MonoBehaviour
         pointFollower = GetComponent<PointFollower>();
         pointFollower.onReachTargetEvent += () =>
         {
-            MoveFinishedEvent?.Invoke();
+            MoveFinishedEvent?.Invoke(true);
             accumulating = true;
         };
     }
@@ -82,6 +82,11 @@ public class GridMovement : MonoBehaviour
                         pointFollower.UpdateTarget(gameObject.transform.position + move);
                         accumulating = false;
                     }
+                    else
+                    {
+                        MoveFinishedEvent?.Invoke(false);
+                    }
+
                 }
             }
         }

--- a/Assets/Scripts/Character/StepOnExclusiveSingleLockInteractor.cs
+++ b/Assets/Scripts/Character/StepOnExclusiveSingleLockInteractor.cs
@@ -59,8 +59,12 @@ public class StepOnExclusiveSingleLockInteractor : MonoBehaviour
         }
     }
 
-    private void afterMovement()
+    private void afterMovement(bool positionChanged)
     {
-        interactTargetObject?.Interact();
+        if (positionChanged)
+        {
+
+            interactTargetObject?.Interact();
+        }
     }
 }


### PR DESCRIPTION
1. GridMovement.MoveFinishedEvent now will always fire after BeforeMoveEvent, with an argument `positionChanged` indicating whether the character actually moved.

No Scene change is included.